### PR TITLE
Hand-in additions

### DIFF
--- a/hand-in/credit-card-server/package-lock.json
+++ b/hand-in/credit-card-server/package-lock.json
@@ -10,11 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
-        "express": "^4.17.1"
+        "express": "^4.17.1",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.13",
+        "@types/uuid": "^8.3.1",
         "typescript": "^4.4.2"
       }
     },
@@ -99,6 +101,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -600,6 +608,14 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -691,6 +707,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.7",
@@ -1072,6 +1094,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/hand-in/credit-card-server/package.json
+++ b/hand-in/credit-card-server/package.json
@@ -12,11 +12,13 @@
   "license": "ISC",
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
+    "@types/uuid": "^8.3.1",
     "typescript": "^4.4.2"
   }
 }

--- a/hand-in/credit-card-server/src/credit-card.controller.ts
+++ b/hand-in/credit-card-server/src/credit-card.controller.ts
@@ -7,6 +7,7 @@ export const list = function(_, res) {
 }
 
 export const create = function(req, res) {
+  console.log(req.body as CreditCard)
   const credit_card = {...req.body as CreditCard, uid: v4()}
   CREDIT_CARD_DATA.push(credit_card)
   res.status(201)

--- a/hand-in/credit-card-server/src/credit-card.controller.ts
+++ b/hand-in/credit-card-server/src/credit-card.controller.ts
@@ -1,17 +1,26 @@
 import { CREDIT_CARD_DATA } from './credit-card.data'
 import { CreditCard } from './credit-card.type'
+import { v4 } from 'uuid'
 
 export const list = function(_, res) {
   res.json(CREDIT_CARD_DATA)
 }
 
 export const create = function(req, res) {
-  const creditCard = req.body as CreditCard
-  console.log(creditCard)
-  CREDIT_CARD_DATA.push(creditCard)
+  const credit_card = {...req.body as CreditCard, uid: v4()}
+  CREDIT_CARD_DATA.push(credit_card)
   res.status(201)
   res.json({
     date: Date.now(),
     message: 'Created credit card'
+  })
+}
+
+export const remove = function(req, res) {
+  const params = req.params
+  CREDIT_CARD_DATA.splice(CREDIT_CARD_DATA.findIndex(x => x.card_number === +params.card_number), 1)
+  res.json({
+    date: Date.now(),
+    message: `Card ${params.card_number} deleted`
   })
 }

--- a/hand-in/credit-card-server/src/credit-card.router.ts
+++ b/hand-in/credit-card-server/src/credit-card.router.ts
@@ -11,4 +11,6 @@ router.get('/', controller.list)
 
 router.post('/', controller.create)
 
+router.delete('/:card_number', controller.remove)
+
 export { router }

--- a/hand-in/credit-card-server/src/credit-card.type.ts
+++ b/hand-in/credit-card-server/src/credit-card.type.ts
@@ -4,5 +4,6 @@ export interface CreditCard {
   cardholder_name: string
   expiration_date_month: number
   expiration_date_year: number
+  uid?: string
   issuer: string
 }

--- a/hand-in/credit-card-server/src/transaction.controller.ts
+++ b/hand-in/credit-card-server/src/transaction.controller.ts
@@ -1,6 +1,7 @@
 import { CREDIT_CARD_DATA } from './credit-card.data'
 import { TRANSACTION_DATA } from './transaction.data'
 import { CURRENCIES, Transaction } from './transaction.type'
+import { v4 } from 'uuid'
 
 export const list = function(_, res) {
   res.json(TRANSACTION_DATA)
@@ -22,6 +23,7 @@ export const generate = function(req, res) {
   for(let i = 0; i < 1000; i++) {
     result.push({ 
       credit_card: CREDIT_CARD_DATA[Math.floor(Math.random() * CREDIT_CARD_DATA.length)], 
+      uid: v4(),
       amount: Math.random() * Math.floor(Math.random() * 1000), 
       comment: '', 
       date: Date.now(),
@@ -32,5 +34,10 @@ export const generate = function(req, res) {
 }
 
 export const remove = function(req, res) {
-  res.json({})  
+  const params = req.params
+  TRANSACTION_DATA.splice(TRANSACTION_DATA.findIndex(x => x.uid === params.transaction_uid), 1)
+  res.json({
+    date: Date.now(),
+    message: `Transaction ${params.transaction_uid} deleted`
+  })
 }

--- a/hand-in/credit-card-server/src/transaction.controller.ts
+++ b/hand-in/credit-card-server/src/transaction.controller.ts
@@ -8,13 +8,13 @@ export const list = function(_, res) {
 }
 
 export const create = function(req, res) {
-  const transaction = req.body as Transaction
-  console.log(transaction)
+  console.log(req.body as Transaction)
+  const transaction = {...req.body as Transaction, uid: v4()}
   TRANSACTION_DATA.push(transaction)
   res.status(201)
   res.json({
     date: Date.now(),
-    message: 'Created credit card'
+    message: `Transaction ${transaction.uid} created`
   })
 }
 

--- a/hand-in/credit-card-server/src/transaction.data.ts
+++ b/hand-in/credit-card-server/src/transaction.data.ts
@@ -1,14002 +1,15002 @@
 export var TRANSACTION_DATA = [
-  {
-      "credit_card": {
-          "card_number": 601100099130000,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 142.80198278114236,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 32.123534146802626,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 493.40853710653255,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 544.0071057428444,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 309.0067268226157,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 318.84423702209585,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 55.854887008465234,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 133.4856766184442,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 122.97032103695024,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 16.194997328202398,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 542.2403448608412,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 299.1544131117191,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 248.715683594322,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 197.67765131750443,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 83.63300835142239,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 944.322241354869,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 415.73303722936987,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 206.68819924304296,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 344.1978423142677,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 230.60022332372742,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 326.2541902174665,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 55.18710104393612,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 445.4086971042644,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 460.1006612333281,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 311.5593899882593,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 54.53543943689161,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 128.19891287312967,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 35.96269883835407,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 132.21319356245232,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 690.1299238092987,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 480.1846363547669,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 362.5856469080001,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 38.371128279829875,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 172.84515707896625,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 28.72088330187844,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 625.2598101354963,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 486.4227112618052,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 215.31011572246996,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 3.9718359798266825,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 704.6720490863753,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 20.38813315001239,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 178.5084761156018,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 153.28583313805612,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 551.1644963535036,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 937.2257152100645,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 397.9408745096695,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 297.4158055991751,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 472.08892948683126,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 27.800058742875745,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 275.4211859188659,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 26.540385788493698,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 26.886909911810218,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 35.210205530949274,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 10.385603464347597,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 286.7331542205961,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 851.0445623698332,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 182.056574228281,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 435.57239577634596,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 111.25565379881407,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 20.603965852196787,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 656.5658431311034,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 82.49048035276942,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 612.9954403645166,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 806.7067497764419,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 53.600503198470875,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 3.0673242998387495,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 341.6152554525143,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 73.47343901476809,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 240.5689662728964,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 862.3312597991096,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 334.5262101715534,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 576.7272170628814,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 444.39351442470814,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 36.3552308978475,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 563.0361460500859,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 113.36045276715018,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 103.50804907437201,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 30.333528992592953,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 189.23200959147633,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 17.195514553552492,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 307.6182324076569,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 273.1473563585538,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 115.46696320971019,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 496.53032184396,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 205.58207263506424,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 63.9836023515737,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 434.4605447897418,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 293.39552953185824,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 647.7886799190201,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 235.55822225091566,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 12.843334422405364,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 125.31486950626588,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 430.5814442465362,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 912.7047829629084,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 613.5254789854558,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 320.61855041169963,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 242.60436525813282,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 574.2456478450578,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 410.71761102930634,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 46.84427644771499,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 473.2582468875765,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 200.93243200455476,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 56.602954192120386,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 398.23591545523067,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 470.35384031925014,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 57.02105813889209,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 896.4891918606742,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 146.50760753607656,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 566.8893423851617,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 1.426757718471,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 225.1245851916414,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 231.6419410460494,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 41.60139168237809,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 10.052439261824611,
-      "comment": "",
-      "date": 1631808781938,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 96.5835228363662,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 189.76083879045802,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 802.2666764993779,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 13.309554052504717,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 173.68261251653647,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 533.3266470986587,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 268.4642174227242,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 2.4537684397310078,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 355.09914894351436,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 242.5297718798051,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 417.9268320371323,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 207.07126891772663,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 525.3834367632641,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 22.330699819084447,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 5.351364130126986,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 202.22870254483988,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 503.2431255343145,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 71.57314680419638,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 245.61930550852844,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 52.105612762015845,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 76.68587143785244,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 400.58978103999505,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 146.78198831043574,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 15.708842088101342,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 333.4640989253012,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 45.67628680016438,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 146.84176134080002,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 708.6769510847607,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 933.3456897645049,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 200.83757962516302,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 383.3903786523247,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 304.65144533500603,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 574.3994901337762,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 335.2828774738585,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 772.3101922768594,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 28.410358999193768,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 73.24598066212562,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 33.09290541866007,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 186.54977323010243,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 76.89005305768818,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 117.33984542884834,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 122.38496326452724,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 43.15818676603529,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 87.0824164549013,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 475.6808571475567,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 76.35843364236821,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 366.80573128072473,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 239.08126441401262,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 127.74699382702188,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 166.07700160313163,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 310.7925493069147,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 94.34378862976148,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 145.81375579633337,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 345.230652444176,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 195.88495723374368,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 19.746786020239195,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 226.296996860543,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 102.70960279086398,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 345.1578532577516,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 408.9768097740459,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 754.8315105875054,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 13.180980941675386,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 180.54208912676287,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 849.081908820998,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 259.29890335441763,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 11.688490448831818,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 351.0850852032884,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 760.7923901262726,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 347.55013776633945,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 59.05364023754416,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 269.2490650143362,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 0.2856680993187579,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 107.20332250812415,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 158.3751205635474,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 266.4539436707028,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 388.86999312606116,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 108.11843247149196,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 727.2383694364453,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 625.0174359923349,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 300.2557671440948,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 4.099041363928436,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 282.75744905713964,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 203.83280502174728,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 92.09337396362702,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 132.00819234672898,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 50.06817163275572,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 102.02698923259022,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 448.45603758340974,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 450.30386634436275,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 170.74525218833875,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 543.4894385105658,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 863.29778402525,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 140.23117748463088,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 396.9938384207925,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 100.754870126957,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 212.72133803747684,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 143.14378604278156,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 626.2590587447495,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 15.560034746274706,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 88.27671544026644,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 89.52511734761029,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 202.13484547507866,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 63.12505486142879,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 4.932861902912169,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 303.9486714873454,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 830.2857441742816,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 434.6008875584312,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 132.38711040519635,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 118.83454334078091,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 637.3745390828767,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 236.81719794016834,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 135.52949433059473,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 205.02063714063917,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 351.5492248108806,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 8.217321616781042,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 253.3940514545767,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 60.78359974730847,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 716.7137881138335,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 334.98807615111633,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 335.5370642872286,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 422.7719125509744,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 238.38230481852517,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 496.4227293632017,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 683.6110282077275,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 185.55934333562917,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 393.6491063436364,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 74.84232597115566,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 144.52040718626407,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 97.91509698232316,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 767.7077353165968,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 212.45019152166037,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 70.26498391551556,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 101.76183335825752,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 717.2326901736778,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 35.17363120628186,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 563.9501535523158,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 135.13184995018014,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 197.1848984643692,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 50.2290679843543,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 157.45491948334066,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 128.88159530104372,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 127.74606703759737,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 335.85349792335256,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 89.96737671071065,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 353.07685455873855,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 63.91875485768784,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 17.010526860685484,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 366.4342700878304,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 195.62514688003967,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 284.1399994382355,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 112.75232802638061,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 394.41668147595317,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 141.99298428497653,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 303.3114545742983,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 572.7704818219532,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 354.0626339272448,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 362.12881182038205,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 586.5125335950316,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 351.5165576446019,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 574.9071310900353,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 240.35496187675525,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 415.3332471083747,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 354.12903268895906,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 176.54864516929092,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 68.47596474993301,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 536.021951387992,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 14.219423865154779,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 580.8909475679823,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 208.29322354832024,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 232.0198804676488,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 338.5990298667342,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 190.80808996415848,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 563.6559294686067,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 542.2536102072579,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 416.53609093409193,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 131.9830915816317,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 161.45713509533456,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 147.34739868854172,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 147.28475420236316,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 534.4019057090629,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 157.42919823761105,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 354.20718494180693,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 918.4329745629944,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 320.6851444797285,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 295.8302908798405,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 590.375568102933,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 245.60108013685468,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 57.977433405604884,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 1.8838922224623598,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 572.4358977021741,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 142.16982972745888,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 308.8027732220285,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 178.56330526759857,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 135.61682446405484,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 123.79487219699827,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 356.05043845122674,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 509.7434272889033,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 288.0051138302448,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 58.015366230804105,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 13.682098665818572,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 47.88750434736476,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 240.2332909045379,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 214.24039607349118,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 31.112327250772182,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 245.02764337041228,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 63.84681189701688,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 352.69253371305643,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 824.2558051077668,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 442.75109446652203,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 54.53057930986305,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 427.57877588601616,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 0,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 298.33663271699635,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 419.6787518711877,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 53.17177374189395,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 6.659411294659062,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 235.22370981560715,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 194.4115078273863,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 30.7835668048307,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 274.8579292058087,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 146.8931693273044,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 8.135096065030993,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 710.1126378597382,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 63.90722363111473,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 227.8508424018824,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 163.20517107694405,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 21.04288175066342,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 200.66058871475286,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 34.01355348981655,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 306.9832646208077,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 60.129115614923386,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 98.09830581758101,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 175.76552951138666,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 496.38765514330134,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 193.90051257353846,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 213.02664895493382,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 295.7188270125876,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 10.205438343251275,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 0.48383428921948735,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 103.60792444589737,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 293.7123594387479,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 148.01221066075993,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 97.8567162850717,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 248.24272826665162,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 122.38503059272412,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 376.35136048203555,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 107.47441493996685,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 7.594996230905537,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 302.0985353825221,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 92.69339037713556,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 197.10841948949138,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 107.56179615100947,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 729.1685148569748,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 50.810981229212295,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 232.67172474333867,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 116.63845588277383,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 12.489176349601617,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 130.40157411645305,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 21.47247597046279,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 12.927181120238895,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 39.008159400618425,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 53.51045581867355,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 734.4913355672135,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 40.93589737577499,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 362.12868926568683,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 77.50370572541017,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 264.82031512113804,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 823.5348845787821,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 594.467037194553,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 170.511097002283,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 624.9457611985863,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 478.97834250813054,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 478.2324268160216,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 675.9687245352475,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 503.34770831528215,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 23.906582449617094,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 80.56436590205531,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 671.3310390764149,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 334.9118145763406,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 319.2061289731003,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 50.85513110454226,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 87.5039804042896,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 511.1829682795227,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 1.1152979408324022,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 373.2572604576844,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 391.42686389446527,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 254.35183119430255,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 128.6921159279617,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 475.0710250646499,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 204.6158917591457,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 429.8679322321498,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 636.3889738403686,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 206.29157480594296,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 586.5786169264719,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 124.80488277529355,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 2.369152658401502,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 46.96262231822826,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 183.74624711625384,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 31.283413547057012,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 14.140175293287708,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 650.8290635086275,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 5.917619964292528,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 29.64711279283634,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 268.68496421978597,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 470.9689327124324,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 294.7804749823089,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 11.229900027464357,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 25.714471015810958,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 73.21054998532932,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 240.6171009089694,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 163.2804712885728,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 740.3520735666394,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 273.84326407671216,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 622.3225767315278,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 365.3202005713228,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 13.606553788214919,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 418.5998617973012,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 241.55451853339295,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 282.1359211200701,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 4.696947519690604,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 548.5961356819482,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 161.51592463028138,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 391.29253735542324,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 468.2289423146845,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 816.8555478864347,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 391.0962442637503,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 459.8480852239862,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 17.847601671242636,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 420.4083924144826,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 289.7597243363057,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 102.30571779910788,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 612.9945688945683,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 58.08144600302889,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 141.79635800105515,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 428.8240231812249,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 13.242626547829778,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 24.94601885340989,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 276.1241918123664,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 364.92917384918456,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 678.1638314606531,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 12.442538823391498,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 192.86772883038768,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 381.4152994105423,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 108.5103689124365,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 352.4995783723094,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 174.46381292350853,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 192.30537495244337,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 5.442405440401664,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 254.63961154182164,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 390.71630399661626,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 289.4657220918934,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 431.5845559844454,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 775.4405219216814,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 118.29895803046652,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 60.153374244517366,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 130.52735450526586,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 108.18924110301806,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 332.26492281585496,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 66.74246694868114,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 90.12461039132866,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 479.47086433021866,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 250.2846729406442,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 32.869973145179806,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 292.0402673195379,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 48.792683468359,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 32.35724846213817,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 49.689332915894035,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 281.5264128768335,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 53.954444176229536,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 4.306389115072955,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 377.63657318032796,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 413.7837624928735,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 326.84699636062055,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 219.94762022484113,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 318.621350112149,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 441.6139596308569,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 73.19022498615134,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 109.99243477378937,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 154.69684412408625,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 32.364597486114796,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 13.564505293237497,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 338.0639140432959,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 8.605336393474612,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 162.40566902755813,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 673.6682745996593,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 256.6409258953895,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 173.92500677941905,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 509.7688344413324,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 81.91837444291478,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 493.1651556406734,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 455.8955277747126,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 129.45114764108737,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 164.34783504390805,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 41.90286534070583,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 363.3384649269766,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 70.09553928984914,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 371.9693272070025,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 197.93479453497315,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 407.0598395668857,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 251.14314502352724,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 252.92522471603968,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 17.839828945705825,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 2.7149512570354464,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 5.808987872553972,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 251.9601237755809,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 173.10088710389795,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 251.5222956083092,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 496.433733234151,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 15.086398211872497,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 6.300089042080273,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 381.30791744278326,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 725.3679005560012,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 446.011054687783,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 176.40675638677877,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 200.57941904406474,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 20.429190803678825,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 219.01674018157252,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 269.05123845055135,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 205.52759157246072,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 625.0189106689137,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 209.54243984811495,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 132.20319646553043,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 393.09958938013455,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 99.58706900372174,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 425.5753489065279,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 465.9111215033673,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 384.86926780988324,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 249.98779869418982,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 252.06647744082238,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 506.8277984007298,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 194.34944685659974,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 201.59257076232265,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 201.92205047006433,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 577.0728245227782,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 118.87172506884892,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 631.7397043112222,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 162.17066192856015,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 554.3851911770236,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 53.121533161436666,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 332.56729645027707,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 167.72728996061596,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 162.46896331948818,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 106.67643424074171,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 61.88920098278412,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 13.26622310304382,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 6.072679719498655,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 384.45695094501605,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 210.99698567735362,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 201.51616400672762,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 254.8150214003205,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 267.1936104845708,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 343.36958012791774,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 308.1110646686478,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 331.14046067598986,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 169.37452956370126,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 1.8756349834637867,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 7.637596525288295,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 124.4084163687438,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 29.485499784384146,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 519.756199437599,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 119.40683770315734,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 181.329313944944,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 21.055734696374568,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 127.22153731329924,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 501.82350685422097,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 264.6124891377231,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 274.5387339752862,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 308.4767359538819,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 58.48523173054267,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 2.9723266513791877,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 492.00595439641654,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 462.40799700663285,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 39.093155419922724,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 17.518848013634354,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 319.25577339357216,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 556.6333362335234,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 676.2858740937079,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 28.08776301412248,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 177.5169333780717,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 138.72483078804177,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 3.294284389300055,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 202.3935156858404,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 108.29561661995753,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 322.7331017953541,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 181.70612681351435,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 220.33781108958559,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 669.2496627952127,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 155.92770304609044,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 327.4819794525059,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 265.3457504100907,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 10.782185154625454,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 88.14014731015776,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 38.429116908012226,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 92.07921808683783,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 363.15776288483204,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 176.88550104475098,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 272.0426799139144,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 122.62159277601128,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 747.3556975625286,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 47.55534781755693,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 118.94591517526723,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 230.1890291376615,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 99.3029047677261,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 36.20387739154405,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 423.1464387603939,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 72.60446550563323,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 8.447502867681218,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 356.0751040310396,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 46.78160050597078,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 716.4000128615277,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 454.8213321226748,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 19.952751102631726,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 306.70017085858103,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 14.205386820424703,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 390.1416430657333,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 554.3908258877543,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 224.81830788105532,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 238.66496116192508,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 54.881693928232394,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 517.5289161016888,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 49.27477591732786,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 164.34557341882467,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 227.15205608788702,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 668.5478723712895,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 264.98261157989197,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 592.7440300828375,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 19.209594123547575,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 358.1517651881047,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 124.48235786452055,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 188.75417551897894,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 192.88574068636618,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 223.8595048849785,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 433.3763180567396,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 133.30818690626762,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 96.80036724474286,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 346.24775368131145,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 911.1765074391717,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 232.78301749996575,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 265.02926446802195,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 68.89398794686196,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 793.7314356479575,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 22.37599845673651,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 13.729337724950259,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 273.4755015229253,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 0.6353302932586811,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 51.67788002266734,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 153.01215129971717,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 14.339317479348368,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 55.49029401460381,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 425.6504335812922,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 146.53929417849102,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 482.74891384751845,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 204.96736450168262,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 681.2493816892777,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 13.144725982482818,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 190.0341623835315,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 172.1986606772552,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 306.1987795796345,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 364.26814532400425,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 433.6189300349112,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 51.02462056525886,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 10.877471218667235,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 393.8844073185185,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 142.73944260411213,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 700.1122809130158,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 58.38035973584732,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 292.21916401241424,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 426.49516293940576,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 3.2114195656213145,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 88.83615213097231,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 69.55123901640297,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 890.5454285843252,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 697.8208563364915,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 273.85834810444925,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 667.9426824899316,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 75.87117226070983,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 347.06469982064107,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 247.69811221854604,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 155.5631466628717,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 336.4521956104789,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 174.2247025227372,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 305.22450307801495,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 28.327766762819074,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 201.53231902215717,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 373.7590686361722,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 147.12388242175638,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 390.9308998765863,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 69.39109438265459,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 201.0509343453367,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 21.928520082989493,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 175.96337082064343,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 573.0129355240799,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 71.86368680034668,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 358.67775165283587,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 137.40113370326716,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 155.21366245619643,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 363.7381293537791,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 277.5038969455464,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 1.3966084512115664,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 134.46570403203492,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 469.5349900496715,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 244.7368254885152,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 31.17299093646823,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 239.26352636608726,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 765.3193524661502,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 1.8566326804193154,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 45.2212962692231,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 140.17569826596298,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 349.01821727535736,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 48.92414091622517,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 84.55090146843492,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 39.113061502770655,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 349.1478720437312,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 157.49421647419658,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 575.0324404146152,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 261.9546876405294,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 280.0062666049789,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 780.6886871549549,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 877.1633252695419,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 4.289896567583103,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 14.041141388434108,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 306.09075606717687,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 271.7650978450924,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 505.63386514140865,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 385.04787792046363,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 4.547156256645743,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 37.95283262234861,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 33.39456667538846,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 265.1157057248981,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 35.288350516619076,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 231.19917613523697,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 274.77677932589074,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 18.829875880343,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 120.33487065882667,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 45.79765036054544,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 667.2241397269611,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 296.18991927206775,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 47.32529118801604,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 74.75473523682692,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 266.3623914154269,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 20.80323776392686,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 171.5904063471643,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 30.503572147737344,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 553.1423970887904,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 107.8909830069679,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 400.2228655929327,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 682.084671998819,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 363.97852223378516,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 224.7744150992777,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 36.04104048935755,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 27.829687266745438,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 793.2014747401674,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 701.2496413622839,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 809.1380430579513,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 47.90819490228807,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 494.8049611368535,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 8.803771488038482,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 61.39166139842175,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 907.6259400706402,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 14.464802773844864,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 518.1045851353025,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 122.3028089045853,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 825.8611175886967,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 204.30801538753693,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 384.5210458333029,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 112.07905163390606,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 704.6389499956333,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 140.27142758786528,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 275.15362039378994,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 602.0784225493,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 139.13720120190754,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 574.9009524822245,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 155.07654749760167,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 0,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 36.91040286298444,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 413.3986475433252,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 599.197895079373,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 124.42962659642404,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 39.822674088692224,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 69.16062609371997,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 916.2902877613366,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 233.85120992965184,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 546.3046306710517,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 448.1080388331823,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 174.77598677298894,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 101.9638809636489,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 277.3473686226323,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 282.72620352812424,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 535.1411938043339,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 407.83750627216006,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 80.96508973371833,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 306.67751941329976,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 161.50591759498224,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 105.5734246297725,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 96.58825643484778,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 323.942575270709,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 17.26756755585012,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 154.48211533708823,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 103.41774831393586,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 100.41442392474352,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 483.6676897278808,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 30.666500613185185,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 64.40601043866526,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 25.38647905436353,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 148.16915006553145,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 26.20946971531381,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 19.82253825797832,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 3.3236797988650055,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 198.04033997239546,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 59.85453685500747,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 5.331160999095203,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 22.056991201309735,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 300.8685106439574,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 5.193629749270067,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 46.766030691441166,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 32.65335324135641,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 192.30304454328413,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 170.01116761411512,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 72.17602618779965,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 127.86718339454171,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 578.8740501052677,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 229.39850634215713,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 99.66876083222299,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 269.0313165601382,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 148.4431275118467,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 54.7595733089369,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 372.5081289792624,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 310.4772583997178,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 177.93823713602978,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 435.65322206056516,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 290.46715142538415,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 515.0513270474394,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 41.99122645848845,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 464.4098941879944,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 855.8380666108225,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 287.9633209282508,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 206.9350630271473,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 96.24154136613306,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 410.38721654431606,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 147.608698451168,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 3.848630698081787,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 548.0678968679438,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 204.46361866365362,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 274.48148754037254,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 74.0585259664556,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 179.0318960596105,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 57.70016177157929,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 129.93628962131413,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 325.9559644417608,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 97.81191284299278,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 426.0404050218245,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 342.89484554790766,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 247.8468774770229,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 4.4129470912016435,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 179.279243601923,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 7.488472160217137,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 233.10739556931142,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 587.2975069694306,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 173.9583489576519,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 230.9106834352368,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 619.2256811534619,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 271.2279713809371,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 250.6137208533217,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 291.0906028470535,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 91.73278750789939,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 27.405773317347997,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 111.67249172970999,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 485.8682681490358,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 306.7181475433652,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 137.84820557409378,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 130.58296457018824,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 165.6880407956647,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 35.140581706083466,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 91.03617550423122,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 125.83307872355921,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 285.4833381261093,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 23.926320532295264,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 52.41460758721687,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 361.09612689290907,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 25.59461544001296,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4001919257537193,
-          "csc_code": 393,
-          "cardholder_name": "Nealon Manifield",
-          "expiration_date_month": 1,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 645.9741290585908,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 105.78881434709093,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 159.10185416761226,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 132.7729763532275,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 8.317496118883998,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 142.03617344134395,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 531.1187199352453,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 120.07948220546423,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 230.65899545023774,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 459.9306398320435,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 285.6950753385788,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 29.006219904887608,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 518.4791953317274,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 929.6515975760584,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 218.47197997718212,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 107.97031548238084,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 652.0284609240881,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 163.75251767091996,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 76.92164453303361,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 562.0196812109793,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 189.85785322521411,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 145.758564762872,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 313.47733004109534,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 184.26761548023927,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 39.45283511561917,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 23.83685154327922,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 434.0838846864652,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 7.693842878313103,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 197.18073333594128,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 24.04577233050994,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 544.0520463536836,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 206.90506976457914,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 221.82347832695086,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 488.4246182247057,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 295.8187472061827,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 247.13297843070825,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 669.3519609106985,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 0,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 743.8554496711172,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 159.5372563417111,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 218.53040601321888,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 43.88682226501558,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 4.427029779062018,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 81.31648902492208,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 118.43770087239794,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 27.359941736859742,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 70.05767725700117,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 135.28174977228048,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 215.51366843890096,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 756,
-          "cardholder_name": "Osgood Twatt",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2004,
-          "issuer": "Mastercard"
-      },
-      "amount": 540.1026137913486,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 22.996895294072527,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6271701225979642,
-          "csc_code": 557,
-          "cardholder_name": "Orelle Renvoise",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Cabal"
-      },
-      "amount": 150.17012457836978,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 23.35302196109272,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 186.4904698957754,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 102.66298737581893,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5425233430109903,
-          "csc_code": 355,
-          "cardholder_name": "Cobb Bruna",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Mastercard"
-      },
-      "amount": 23.933478878316812,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 208.5261695655072,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 249.62074169298384,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 172.4925029591833,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 139.28509202161464,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 111.7674028726099,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 2.3006037127076535,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 116.7152175940021,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 227.30714750023378,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 601.2964693388293,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 320.46098260229695,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 313.01462956870637,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6011000991300009,
-          "csc_code": 964,
-          "cardholder_name": "Ardra Frankis",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 521.5505705777583,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 155.49125300827575,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 474.8565495860883,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 241.2844394890098,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 44.33404521249377,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 261.07514675252094,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 589,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 308.45602497110394,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5200533989557118,
-          "csc_code": 694,
-          "cardholder_name": "Roscoe Grumbridge",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Nativa"
-      },
-      "amount": 170.0903770144522,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6362970000457013,
-          "csc_code": 543,
-          "cardholder_name": "Ferdinand Ovell",
-          "expiration_date_month": 10,
-          "expiration_date_year": 2023,
-          "issuer": "ELO"
-      },
-      "amount": 337.62903703978094,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 505.46415261509173,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 654,
-          "cardholder_name": "Gale Persian",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 7.078936793098207,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 7.797421211706629,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2222420000001113,
-          "csc_code": 812,
-          "cardholder_name": "Cilka Sindell",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 414.44657324817297,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 580.707891822299,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 5011054488597827,
-          "csc_code": 374,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Argencard"
-      },
-      "amount": 76.62450890399607,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 208.0083492774833,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 529.5479647377306,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "NAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 342.88219013984167,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 219.87581957590328,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 42.12442309510788,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 5895626746595650,
-          "csc_code": 132,
-          "cardholder_name": "Peyton Robelet",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "Naranja"
-      },
-      "amount": 53.70476444999831,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 514.5681615790305,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 76,
-          "cardholder_name": "Simone McPartling",
-          "expiration_date_month": 4,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 20.638550944538206,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 39.376783975809154,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 92.92851291147713,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "USD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 447.14213274288284,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 374245455400126,
-          "csc_code": 432,
-          "cardholder_name": "Horton Rushby",
-          "expiration_date_month": 5,
-          "expiration_date_year": 2023,
-          "issuer": "Amex"
-      },
-      "amount": 1.7288578851962395,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034932528973614,
-          "csc_code": 412,
-          "cardholder_name": "Dilan Renn",
-          "expiration_date_month": 3,
-          "expiration_date_year": 2023,
-          "issuer": "Cencosud"
-      },
-      "amount": 12.461818351752354,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 3566000020000410,
-          "csc_code": 323,
-          "cardholder_name": "Kattie Caraher",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "JCB"
-      },
-      "amount": 352.06348897413045,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4007702835532454,
-          "csc_code": 132,
-          "cardholder_name": "Marvin Tufts",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 63.75224266462382,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 214.37387360072412,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 4917484589897107,
-          "csc_code": 420,
-          "cardholder_name": "Jennica O'Crevy",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 14.703605402048865,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 20.41541499402961,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6250941006528599,
-          "csc_code": 874,
-          "cardholder_name": "Levy Romeuf",
-          "expiration_date_month": 6,
-          "expiration_date_year": 2023,
-          "issuer": "China Union Pay"
-      },
-      "amount": 596.2666240459134,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 6034883265619896,
-          "csc_code": 225,
-          "cardholder_name": "Ervin Connor",
-          "expiration_date_month": 11,
-          "expiration_date_year": 2023,
-          "issuer": "Tarjeta Shopping"
-      },
-      "amount": 114.86053610169184,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "KYD"
-  },
-  {
-      "credit_card": {
-          "card_number": 4263982640269299,
-          "csc_code": 173,
-          "cardholder_name": "Laird Mulvin",
-          "expiration_date_month": 2,
-          "expiration_date_year": 2023,
-          "issuer": "Visa"
-      },
-      "amount": 645.7379027737654,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 2223000048410010,
-          "csc_code": 102,
-          "cardholder_name": "Olenolin Glason",
-          "expiration_date_month": 9,
-          "expiration_date_year": 2020,
-          "issuer": "Mastercard"
-      },
-      "amount": 2.664963867845449,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "MWK"
-  },
-  {
-      "credit_card": {
-          "card_number": 6062826786276634,
-          "csc_code": 686,
-          "cardholder_name": "Jacquelynn Moyles",
-          "expiration_date_month": 8,
-          "expiration_date_year": 2023,
-          "issuer": "Hipercard"
-      },
-      "amount": 29.529030179972413,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "EUR"
-  },
-  {
-      "credit_card": {
-          "card_number": 60115564485789460,
-          "csc_code": 231,
-          "cardholder_name": "Raynell Hennington",
-          "expiration_date_month": 12,
-          "expiration_date_year": 2023,
-          "issuer": "Discover"
-      },
-      "amount": 49.68943086021524,
-      "comment": "",
-      "date": 1631808781939,
-      "currency": "CAD"
-  }
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "ab0db488-b6c1-4888-97cb-e7e5c568fc5b",
+        "amount": 53.65880917215095,
+        "comment": "",
+        "date": 1632755177922,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "7e0fa1cf-2ee8-493f-8ef4-ab2ccbba323e",
+        "amount": 4.893942243004438,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1e71fb5f-af44-490e-b765-abd9c24e7828",
+        "amount": 336.63486000379874,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "7dd692da-e797-4ed7-8502-b192799e8ccf",
+        "amount": 194.38094200497264,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "0fa60c68-c3e2-48df-bee9-8a52728c273b",
+        "amount": 549.1420257864478,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "2a7cadc8-ecb8-40be-a3d8-bc825e76a437",
+        "amount": 205.08903474152945,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "549caa36-fca7-4393-9956-3c54552d27e6",
+        "amount": 25.247057044423187,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "cdfe0f86-83c0-4d3d-a9f0-3840754332db",
+        "amount": 117.61065089952933,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "fa4ad972-6c5f-4622-b0c5-cd805b5e723f",
+        "amount": 10.698281712284754,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "8c91c27d-1241-4d52-a825-8976841fa6a4",
+        "amount": 652.5976345699784,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "5ef5fe4a-ed9a-4c40-932f-2bc4a166a87a",
+        "amount": 27.496497598874782,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "09a16a2d-4368-4553-9219-510211974706",
+        "amount": 287.60002005948587,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "5682e30b-5e70-481d-9422-16620b5f0777",
+        "amount": 559.5421631290383,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "81ae178c-32f7-4782-b457-58942f49d55e",
+        "amount": 178.2026305448218,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "8f82d60c-e630-4c9e-9a0c-ced6dd979c66",
+        "amount": 27.91135452969815,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "11bedfb2-4865-4871-9691-4910b13854dc",
+        "amount": 445.6173323605853,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "cfe39ff4-5071-453b-be67-1aa48fa71a29",
+        "amount": 170.04769968766834,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "1e4e3a85-ca2f-44a0-b837-c26d57640728",
+        "amount": 303.76194054204996,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "af627194-a8d9-48d4-b055-397347f40978",
+        "amount": 733.7133889889548,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "2f55ef85-11f8-45ed-8c18-fda6e9ab4cf8",
+        "amount": 293.4640486839134,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "24b83c61-2ad8-47b2-9dbe-498cbf281e20",
+        "amount": 297.7841552418911,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "6fd54363-0628-4ed3-abc7-24876595bf4c",
+        "amount": 14.321931934162253,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "e60c789c-12d7-416f-9ca7-2c6c37ab5219",
+        "amount": 147.21724305139915,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "05864326-4e59-4b11-94e2-d29cc801a5a2",
+        "amount": 246.67653570203836,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "ff46e53d-8dac-46de-9dc8-d0f834bf7982",
+        "amount": 309.07244049102667,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "4e68683d-81b6-4130-8625-e7e6b69337b1",
+        "amount": 170.00022032904695,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "e220105e-72c5-4889-a67d-8372ab0b1e18",
+        "amount": 31.474711520066627,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "8f6a86a4-aa18-4b70-964c-c63aa8c4afde",
+        "amount": 516.1425333637479,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "89863575-207e-4906-8232-b307102b8b05",
+        "amount": 305.8357941944428,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "49289f06-1567-4f3b-aff5-ed8c5f457772",
+        "amount": 111.83287022272954,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "7d73b836-6ce9-4fae-8947-03547edf8b79",
+        "amount": 449.562157293837,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "b19a0b5a-ad8c-4c50-baf1-f0cdc33fb2cb",
+        "amount": 237.11492545921135,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "c87ae0c4-9155-406b-803d-fac84c45796b",
+        "amount": 574.6778124134544,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "9bceeebb-f879-43f3-9d50-7d358a1f0e76",
+        "amount": 8.570280933522485,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "812b3b44-1903-4b9e-b629-b9f5341efda8",
+        "amount": 459.41174133648315,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "75ccab38-a772-419b-a582-5e2b17d522d2",
+        "amount": 131.8409933483719,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "53447f01-8c46-4d54-b314-58e93d6d4de5",
+        "amount": 47.05465053354845,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "037350ce-463d-4877-b446-311285ba0041",
+        "amount": 18.63160744687653,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "a7e3f94e-76bf-4589-89b7-cc887ecb8fa9",
+        "amount": 168.03807545852214,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "6eabc7f9-3347-4f5d-9baa-b52e3a506fad",
+        "amount": 29.115972629531882,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "89e920ff-761c-4117-b0fb-2f265d725229",
+        "amount": 451.2462754510867,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "f6aac24a-601e-4044-af1f-b2a896c87a74",
+        "amount": 542.2463366971584,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "8d3e34d6-7f42-49e8-9545-ef3144733a6a",
+        "amount": 48.07791226190237,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ee56fe5d-45c1-49c6-b502-ccf2bfcb91f0",
+        "amount": 194.5891742138065,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "6f54e3c2-7fe8-4bd5-80b9-5d9b9bce4a76",
+        "amount": 153.9031509260895,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "b087469b-550c-4d6f-b1dd-79423b9a92cc",
+        "amount": 13.834510057132928,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "1c86f38f-6cb4-4d04-af01-01973162ec46",
+        "amount": 19.53082613248901,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "74e12eea-349a-4e20-ac8f-85f56c3201ef",
+        "amount": 156.5642312675917,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "41911297-d949-46e6-99fa-f033d52dc6b1",
+        "amount": 67.01841230844445,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "aecba069-9589-4d38-a073-74c35c7014c7",
+        "amount": 123.18710159127099,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "34e0465b-a5e5-423b-9a6d-913de620be85",
+        "amount": 63.689240763103946,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "126e1632-7aa5-47e0-9770-34a0f0d2e6c1",
+        "amount": 412.37771746944793,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "86b40a53-7df4-4843-b9b6-b4d9184a1c9f",
+        "amount": 166.95274748948427,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "bbbe368c-f87b-45c8-bdc6-857c0512e5ee",
+        "amount": 775.0089434163602,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "afff8a69-e334-4a09-9c0e-41f857ee8054",
+        "amount": 443.6707193251469,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "43fd365a-c583-4f82-8354-12ffada135cb",
+        "amount": 75.83283275355096,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "6a7d4648-a396-42a9-8402-d0a2bedc30df",
+        "amount": 218.8237160658949,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0235c031-3980-4535-bc1d-bc69248d9ba6",
+        "amount": 602.4304549384233,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "d505e94a-c7ee-456e-a78f-1dd060c1cf22",
+        "amount": 70.5062811235548,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "96a7643d-5f24-4c77-8ffe-a67e23efad8a",
+        "amount": 424.77590578072517,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "61a0c69f-4ff7-49cf-8061-03260648120f",
+        "amount": 143.1195331644914,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "e94a8074-ccb2-4dde-8195-3e66b6a56084",
+        "amount": 289.8192570741603,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "fb4bbd1b-2442-4262-bec4-f0288b52e0f3",
+        "amount": 28.026184621625468,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "ea9054e2-3312-4e98-9302-e40d867004bb",
+        "amount": 182.06262712942842,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "a21b9d59-3112-49a6-8db1-1e23f87e6995",
+        "amount": 59.42085449689708,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "5fbdc726-d636-4223-8654-d447d1b8f145",
+        "amount": 112.24771974509399,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "8b2500c9-521d-4229-b0df-3ecefba2deee",
+        "amount": 122.05540280943423,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "482e80b4-72f6-4c9d-90a4-68d646c14523",
+        "amount": 313.30617777482104,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "d09dbf41-7cd0-4072-ab3d-b1612adfcf81",
+        "amount": 306.04156888202124,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "2e50f620-286f-4598-9bd3-cf2d7d1673d5",
+        "amount": 148.69709778704762,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "9d9caa2d-8243-4d40-968a-f78913c890f4",
+        "amount": 144.17818730216288,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "96a06acb-b3ab-4086-9959-75c1086d9b1b",
+        "amount": 674.8384625985494,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "1d528942-21fc-4eda-8cff-37f9fbd26655",
+        "amount": 98.0271506109492,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "6eba0c58-1309-4189-a54f-2af16b1c645e",
+        "amount": 216.23732954847412,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "82065cf4-4e84-463b-80a2-4edcf585c001",
+        "amount": 544.2852083834524,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "844e6011-14cf-4ebd-bfad-3c17872af35f",
+        "amount": 494.3627249676592,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "12aefef6-e329-47a4-93af-a35cbbaffb61",
+        "amount": 295.56644670395605,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "37c9add2-95dc-4089-a8de-f1b431a48719",
+        "amount": 31.812923461200523,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "67f83b39-ddf8-4f08-8445-ad67a9031795",
+        "amount": 238.2753420495765,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "074cc25f-e3d5-4297-9d54-55989645a8f2",
+        "amount": 119.55783059614788,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "b37be3f0-3c63-4baa-88b5-8ba800a555bf",
+        "amount": 198.18143553895968,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "f431ba68-6e36-4fdc-a6f0-e9192686f682",
+        "amount": 124.38739007515518,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "11866a07-522b-4c54-a564-054b986604eb",
+        "amount": 37.66191497032397,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ad992082-bbeb-4c02-8216-63ead83c9eb8",
+        "amount": 60.03004647779848,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "56b43118-00a1-4f39-a553-c43e4c96daf8",
+        "amount": 10.551729562215696,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "2996b4f6-7133-4856-9172-6f00442f9025",
+        "amount": 372.7744878549725,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "216736d3-fa22-4613-9627-b9805e94da89",
+        "amount": 444.51401931988914,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "bd5c5479-6396-4e42-9941-33dc2723976b",
+        "amount": 56.76439286894407,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "e147a214-4487-4fcc-9c0d-afbe02cac050",
+        "amount": 252.01793881644085,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "d314a122-14e4-408d-bfb3-1ce7266b72f4",
+        "amount": 28.416212353919644,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "5f31646e-be04-45a9-874c-d3f15a19b7d9",
+        "amount": 1.1084140898679304,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "e5ca3f27-b3c9-4442-8225-e343a4be63ce",
+        "amount": 371.95287690641914,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "d21d24bb-807f-49f8-8ea4-313246dfecc1",
+        "amount": 252.13442786426847,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "201d4389-6267-461c-80d0-ebe4620679b7",
+        "amount": 22.62424674018127,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "b016e4e0-bddb-493b-9415-f687e6cb0fda",
+        "amount": 4.017057279848478,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "f4183338-0465-488d-8612-a8dd3a756a64",
+        "amount": 813.0224353273297,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "7cfbedfa-7832-4ee8-9f67-31910f14549e",
+        "amount": 9.072018323596724,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "34525291-1efa-415b-8cfc-8ff7fbb02c76",
+        "amount": 200.06108229590174,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "134d5f26-2182-44f0-9f32-7a909f4753ab",
+        "amount": 386.56930617912144,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "6480024c-2aa4-49a8-8446-e3171e70a784",
+        "amount": 7.207237940478613,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "b556d413-4781-404c-841a-3bf6c8fae948",
+        "amount": 203.5341178503183,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "131ace3e-360b-414d-8c0d-95c2791a84b0",
+        "amount": 121.35265876455398,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "64cff563-675e-44a0-a79c-c6313b17dcbd",
+        "amount": 61.393571357140594,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "6b9051e6-7826-400d-87c4-d7ea1916129b",
+        "amount": 250.15005909032666,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "3e7c3dbb-5fa1-4546-adba-7c6ba3ba25ef",
+        "amount": 251.46675203798372,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "8bdbc5b8-590b-4eaa-aef9-b9e0c4bbf620",
+        "amount": 432.37701049624155,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "47c10e6b-5fe7-44f2-beb6-5274ce604eec",
+        "amount": 0,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "5406bed1-93e5-4617-a21b-262215b57cdc",
+        "amount": 29.771594021158037,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "4b19ae7e-d0bb-4ea0-869b-20f1e2ed3796",
+        "amount": 35.411446495626706,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "d719379c-233c-421f-b896-7c3f81483195",
+        "amount": 12.000130345926207,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "b1ecba25-46aa-4da2-a3e6-cc5cbb5ecfa1",
+        "amount": 24.006820945224803,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "2aa1d0aa-5832-44f3-83cf-73ad07436ab2",
+        "amount": 604.1288689338843,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "cca6e28e-ac29-4207-a91e-dd5d7795ab4b",
+        "amount": 11.04053549462842,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0881a613-08bc-470c-9c0c-2429229b5c4f",
+        "amount": 76.04826016503486,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "b4b7badc-e5fe-4ff0-81a6-2323f5f363b0",
+        "amount": 12.247683534862018,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "65cbe707-e70e-4b03-aba9-d229a03695ee",
+        "amount": 565.4275625462116,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "686913c0-0287-44f9-8604-8876f5c1cdac",
+        "amount": 5.770502199242325,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "cfe4162b-de63-4904-96ec-08b9aaad743d",
+        "amount": 96.59544926257915,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "bf004d7c-1cbf-4794-bc8e-885f0adb0e19",
+        "amount": 84.90513595740597,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "d904ab6a-ea44-4c7c-9b80-44aa62c42a59",
+        "amount": 188.6652243110654,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "709e2bcf-3712-4f5b-80ac-d8116d27307f",
+        "amount": 803.1549987113558,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "4e7d4702-6c50-48ed-93a1-f626b05bbe46",
+        "amount": 36.306798114817475,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "d487be7a-1cf0-4bef-8d1d-ef11f15c892f",
+        "amount": 197.33886099384716,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "be78f704-9525-4a59-b0f8-c197087b8f52",
+        "amount": 127.05629840260252,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "7356146e-8a8c-44c1-8dd3-246302b4c221",
+        "amount": 11.056062238483326,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "4ce69e5b-dca3-454a-9dc0-5b7fe7cd2ed0",
+        "amount": 850.9416522156783,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "6f8e769b-d5b4-485c-8e5f-209ab1e18739",
+        "amount": 139.89786100380414,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "4c04abe3-e983-4410-9dc2-1fa744e85e8b",
+        "amount": 447.8747021473091,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "f6c5e53c-ec38-4570-bd10-34fd71916915",
+        "amount": 199.146090719369,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "b0f2d0bf-9542-4c85-bcbe-5e99e0553b78",
+        "amount": 41.77224952421489,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "cb330534-2dd3-4089-a651-a657803b9e19",
+        "amount": 21.00568758619987,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "68ae0a2b-1897-40fa-9db2-87ec7254942a",
+        "amount": 0.13561538849276578,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "c95bed9a-6fcb-4d06-90ba-ccdb321c44f7",
+        "amount": 126.46701487859956,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "4796a235-f8c2-494c-9fa0-be8d3841f810",
+        "amount": 44.40384305296201,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "74672796-28c4-446e-b0ac-e8ede78c7563",
+        "amount": 63.22561934248745,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "5bb23ae9-b337-4c02-803d-78d842118ee0",
+        "amount": 128.26661115720964,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "5906b74a-b662-47bd-b46a-5c0f0f14af70",
+        "amount": 615.8365410715294,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "e461569b-2ae1-436a-aae1-a94411155b6b",
+        "amount": 944.0524498185654,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "bb5a90fb-baf5-4286-815e-410993bec5a7",
+        "amount": 6.1828946745368745,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "54a6eb0e-dad3-465e-a75a-fcb96ad97b21",
+        "amount": 202.29004101706818,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "99e4bb8b-586c-47c0-85ac-b5e197d94ca5",
+        "amount": 18.531015962701638,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "e8162da1-6fca-4b95-8bd0-7ee0e0c2b1aa",
+        "amount": 207.58823282001086,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "716310c5-fd42-43f5-bc65-8fc5458fa096",
+        "amount": 145.84882338218918,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "a5f9000b-063b-4271-9e69-d97607a6d13f",
+        "amount": 124.6551927281597,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "5c40f137-158d-4443-b032-c367803a7989",
+        "amount": 957.3644828723722,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "527d74ef-8ee6-461c-9762-0406e1ea9040",
+        "amount": 26.43968537968293,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "30cf9bc2-ff05-4aab-8b49-1acbccc441a1",
+        "amount": 8.712335918972485,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "cca8b5f5-3d8d-4d1c-b057-08520d5d42da",
+        "amount": 2.4868682579682977,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "d7e13d78-d30b-4980-9309-d06718e281af",
+        "amount": 6.827651485982945,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "c23f2b5e-8285-41cf-9b4c-09097efadabe",
+        "amount": 370.09080844825854,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "e9633b1b-0fb2-47bb-b5b9-eaf3900529ca",
+        "amount": 53.669499666509864,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "35ca6b41-1ef7-4192-9f51-52ef935272c9",
+        "amount": 63.28288301244472,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "fbb9af09-65f1-4451-91a9-762541f31588",
+        "amount": 346.2360052813611,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "709ce6f8-761e-45aa-8fab-20da6e5bae76",
+        "amount": 415.4673759259294,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "bbd1b5c7-2839-4ce7-880d-008bd1710eb1",
+        "amount": 55.44817948586321,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "d8d38930-d583-4f07-95b2-a5b9aa3a3016",
+        "amount": 127.38767646275217,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "1fea6781-cfcf-4dd0-b511-a83d2bfdfe33",
+        "amount": 147.58655253014444,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "4713d352-4690-4b4c-be58-70e6eed72039",
+        "amount": 615.1427312307503,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "e67a8c4c-211d-457c-84d0-6db2e965c15c",
+        "amount": 314.1733155979552,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "9656ba86-78d9-4d6f-9188-2d37e2a5b398",
+        "amount": 527.972041895219,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "78a45296-d122-4be5-9b38-7e475f393fe3",
+        "amount": 238.23724206955444,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "9d70002a-43dd-4c69-adc9-68eb46196a04",
+        "amount": 191.61759696899978,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "0bd1bd83-e0a4-49fb-a7f8-000d61c3b774",
+        "amount": 420.7171160515743,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "b3db2695-ae4e-4e6b-b62d-50cab6e9763d",
+        "amount": 394.69151408359556,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "526ef4f0-dd3b-4bfd-878f-3c8ded608039",
+        "amount": 465.97874003270834,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "0cfa1fab-f5ad-4677-a326-e6136915b74e",
+        "amount": 341.8486762471306,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "79df08ff-4cc3-4b57-9906-8c7099727ad6",
+        "amount": 743.5244824887307,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "bcc9b558-f6a2-4eec-8fdd-c1491e82907f",
+        "amount": 257.72534843720655,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "65618e5e-0643-4112-8098-36a99901d812",
+        "amount": 107.67176650034192,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "fcd7aa35-ecc4-4b53-87d4-4a597aff97db",
+        "amount": 399.12866142602263,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "cf817fe8-0c16-4e86-a485-5fa10a5dfa79",
+        "amount": 26.962346587934803,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "e8d25d46-ba78-40a4-bd84-5e6a9f33cab2",
+        "amount": 112.47308691071841,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "9fbc2b0e-6b4f-43bd-aa2b-3d11aed802f9",
+        "amount": 274.18840712352414,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "f2b81062-cbcb-420e-8c09-0cecde8cc245",
+        "amount": 161.73077309744147,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "71f5f230-5b13-44a1-8bd1-76df21a51145",
+        "amount": 941.1013772209172,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "d596b018-cb3b-48df-91c3-50842af10fcc",
+        "amount": 308.258200819935,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "f6027130-f23f-42ed-9d1a-788ed6601813",
+        "amount": 152.08613238703373,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "7a7bc2a6-84aa-4f04-aeb0-1677ad32aa3c",
+        "amount": 43.420380938329174,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "5b8a3386-b1f2-4743-8ed1-a59659096def",
+        "amount": 69.84755825989228,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "c478ca75-5738-4610-92d6-51d7fb19df32",
+        "amount": 41.63213071397243,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "12e9e53a-cc50-4600-9b3a-79b79ae94c03",
+        "amount": 407.09443425312287,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "f231617b-375f-4cc7-9269-c29467e06d95",
+        "amount": 399.7163084173971,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "383dc5d7-d4b9-42b5-87bc-bbeba06b6eac",
+        "amount": 130.15275829934436,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "04336a9f-4ec8-4ef9-b637-eb9ffe851a2d",
+        "amount": 406.95373096606363,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "a44a6a69-6068-49c1-9884-43c919273aa2",
+        "amount": 165.48814870972413,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "002172bb-abb9-4006-8442-95f8e5b7b5f9",
+        "amount": 169.52471691464703,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "bce45241-308f-4546-9468-fe8073e96ff7",
+        "amount": 369.4636511719516,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "62efcae4-66ff-4170-96ec-6d9e524b30d6",
+        "amount": 357.2894678360786,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1d32b122-7cee-4091-8fdd-28004cef19ff",
+        "amount": 186.40187695943538,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "2e50e42b-36a8-4145-bb1a-031d0bcc13bb",
+        "amount": 376.0995964236019,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "0c23be11-976f-4876-a70f-b4b4b4bb6963",
+        "amount": 438.07679280855564,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "27155980-0fe6-420d-807a-0b9f63df1369",
+        "amount": 532.2206531623606,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "bf4ccd76-7a5f-441f-93de-3d5505581a52",
+        "amount": 134.4518901323185,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "a6a6d16f-bab2-411a-a1e6-c2a582543acc",
+        "amount": 31.857069496539307,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0ff234b4-dfe0-4e5b-af19-066526042b0f",
+        "amount": 464.6005577968284,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "1875b79a-3567-43e8-91d0-aaba8a0ca78e",
+        "amount": 396.3527465815801,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "7a89fb33-03a2-473a-94bd-6ddfb55b3b54",
+        "amount": 361.54202928377396,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "d11773ba-0937-441c-9815-b68496656289",
+        "amount": 413.3448745271397,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "5fc581e8-d97d-4204-bce6-bc01d2f4e311",
+        "amount": 16.071422481963047,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "69ed6234-8e90-46e1-b580-3134f6e2ed89",
+        "amount": 3.6206421150978634,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "f9080915-dc3a-4cea-b8b2-761cf35de2e9",
+        "amount": 347.86182990042937,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "ede69f6d-dadf-4205-8109-c5beb6b68502",
+        "amount": 125.20055657566627,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "b8eb4779-1067-4a18-b15f-d3e3535ed4c8",
+        "amount": 163.2847852251789,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "ecbb0efe-e181-4e7a-b5d4-99f95f80c08f",
+        "amount": 21.004984561600732,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "3b7309c4-60d1-4e89-b1b2-cff26c1a02f0",
+        "amount": 700.2840639250107,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "79f537de-f80f-4dbc-8f52-1f3275303a55",
+        "amount": 116.34722961485186,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "21a8b935-3b57-44f2-8617-618b40043a72",
+        "amount": 5.405068174399746,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "4c0a8f32-923c-4700-9d5a-b7a566a98e0d",
+        "amount": 110.65416884438507,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "7422c796-e787-42da-aecd-88d807c1487c",
+        "amount": 29.151695350382067,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "4f188c88-f9f3-4195-9c18-3fedfb48fb9d",
+        "amount": 3.715062649999913,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "b2a0ead0-c394-4402-b785-6676f9bd44ec",
+        "amount": 116.04188244256142,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "0daddcdf-17b8-47fb-b790-adf3ae1d0ef3",
+        "amount": 193.0563276413504,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "90d4cffc-7a46-49d1-8fa5-95dc5e944bec",
+        "amount": 143.07681208592288,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "9ba848a9-8e0e-45f2-8dac-74c9a36e6022",
+        "amount": 850.7640470391644,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "575c5402-c24d-490c-aca5-96aded93561e",
+        "amount": 444.59932393103367,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "972e7dde-422d-440d-aee1-3d9820d264f3",
+        "amount": 963.6509512693959,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "d360279a-587a-4caf-9515-fa8e697ec88e",
+        "amount": 64.00435039678288,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "6231e43b-b778-4873-9bc9-d4b50ad257f6",
+        "amount": 74.27252115139059,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "4e2ed526-e907-4544-8cc0-3451c48b4529",
+        "amount": 13.601174191582295,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "b417645b-4e5d-4271-8c7e-1cb41faabfe1",
+        "amount": 4.055567400571866,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "e2ee4de0-d980-4692-9c45-142c218eabeb",
+        "amount": 17.56124992928991,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "c485ae96-ceaf-4525-9f9b-af14d06ef74d",
+        "amount": 464.8546916938253,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "806c947e-ff1f-4c5a-abe4-807a25707069",
+        "amount": 516.6809689567121,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "ef9098f6-eaa5-4999-a882-e58d44270130",
+        "amount": 17.870147985893137,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "aa5393d9-be80-48ee-9e39-9c07deab3ba2",
+        "amount": 105.90096270853094,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "a5b3216f-a557-4425-a38a-e1ab4671d434",
+        "amount": 770.4189926422844,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "3fb2759a-4b17-4097-a423-b97bef475084",
+        "amount": 591.4453920475587,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "44eae36b-d686-464f-bd41-239ec7ee4d79",
+        "amount": 42.03124868168742,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "bc68d3f8-9322-42f5-b5af-7e991923b728",
+        "amount": 38.47951425210264,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "2d4ce04a-fc8f-46a8-9186-b90698c71257",
+        "amount": 421.7728324057278,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "8a82caa4-9c95-485a-af63-45810aeaec61",
+        "amount": 376.7328264052116,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "43c896c4-da00-4d9b-9005-d99abe251de9",
+        "amount": 14.92163438716328,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "eacc8aae-7776-4c34-9093-6c51e53980b8",
+        "amount": 519.5275539032883,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "806bce8a-d694-42ac-8d06-7975f0686f14",
+        "amount": 864.5769688983943,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "996b9386-9501-4f48-ba6c-37ab70d6c48d",
+        "amount": 121.23496932968352,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "d0b11aea-eef4-496a-97d2-46f34fee3bc0",
+        "amount": 512.0557031898786,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "337cb663-f2f4-4b99-b476-56a92bf15b67",
+        "amount": 238.90483839875674,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ac31ff5a-cb41-4559-a68f-922d611e176c",
+        "amount": 43.78071409261972,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "c89674cf-02d9-45b4-9c35-a3fa7526e288",
+        "amount": 197.9890505706238,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "29806eef-b259-400b-8086-ab7edb56b18c",
+        "amount": 292.9898412117273,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "ab7a7cdc-76e8-4509-be3d-7e2f5956770e",
+        "amount": 5.8576411307523095,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "acf93506-603d-41c6-9845-c6c59654352d",
+        "amount": 253.43554161991676,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "09974d0b-a6bd-425a-9289-40967947e287",
+        "amount": 183.87428542116737,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1afce275-397e-4d1a-b8cb-d204137a520c",
+        "amount": 0.28380359748441575,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "8f780837-1bf8-445b-9f8c-a7ba616d142f",
+        "amount": 142.37187516829692,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "39c15612-f7ee-4263-a9e6-df1ace707b4f",
+        "amount": 437.75847150514517,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "53823962-fadc-4f78-86c7-60b58192c722",
+        "amount": 447.2874764675098,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "2273233b-6c93-4f6f-9b2d-917c85a1fdc5",
+        "amount": 13.990968492531962,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "10eb2b98-ac7a-458c-a41c-458dd8b4a6de",
+        "amount": 313.23278123014023,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "89d4e6e0-d8e2-4702-a3b4-377c19ab23a7",
+        "amount": 119.410746846131,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "9c0f75a4-2878-4749-8d9e-62951b2cec9f",
+        "amount": 294.9883963960629,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "76a502b3-32fc-4147-b4f6-7ab090e32758",
+        "amount": 106.67952412891792,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "203ddc52-39c5-4ea4-878b-40de29d79000",
+        "amount": 271.08542431373286,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "0aaadaba-53a4-4edb-a75d-2d8a4755b1bb",
+        "amount": 28.98784989375884,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "d97ba70e-f159-4061-8195-d8dc5a83a029",
+        "amount": 386.058094298775,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "3e39a9a6-8fe9-4012-8481-689c098e7d93",
+        "amount": 42.81392190224895,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "b2ad9496-8b52-476e-b997-1db02fad89e0",
+        "amount": 77.33863448068894,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "c4485315-c5a9-4f2c-8623-1a9fd7655f97",
+        "amount": 785.7614031927105,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "ce5acf99-61bb-4200-8655-b8c478996e69",
+        "amount": 92.65032217467001,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "13861ad6-39dc-4606-9cf7-649e287a7e36",
+        "amount": 11.224006979624146,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "7d4bbf12-d2c5-423c-9860-768f4208751a",
+        "amount": 271.05516655842365,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "884f1a21-675f-4c74-9ba1-16f3c0b6eee6",
+        "amount": 122.74620571130566,
+        "comment": "",
+        "date": 1632755177923,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "1f610d54-4af7-43e4-89b9-be2af039d03d",
+        "amount": 534.925316799408,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "60cc63d5-33a6-4968-8904-7c9f8c4382fd",
+        "amount": 318.81041484977095,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "6e1a6bc3-b6c4-4c98-bdfb-b3787bf1fd2a",
+        "amount": 89.31244818371917,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "575eff4e-3e95-4062-9a3c-a933b9ea7941",
+        "amount": 648.8868947990701,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "b615bab6-7b9f-4552-8d0d-c87ca1388ffc",
+        "amount": 6.649707938487523,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "268d2d52-211d-4a7f-bb7c-886314099990",
+        "amount": 24.085619611216437,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "e706ed89-ab52-4948-894a-8771d7c93712",
+        "amount": 878.0510066024976,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "d386a13a-bfe5-4869-ad85-067600a0cac9",
+        "amount": 67.27089140324226,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1b1c9537-211a-4f9c-be92-0d7cfd475f30",
+        "amount": 64.23453118892408,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "4f219c4a-9077-495c-956e-ca38b76b5e04",
+        "amount": 24.470292227601295,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "0580c414-5e52-42bc-9bef-0c5adbc6375f",
+        "amount": 135.55308392597246,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "7bdb4bf3-b90b-46e1-aedf-108a6ffdd88f",
+        "amount": 109.21995583350085,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "9c9c200f-adcc-4791-91b7-f0dd682116e9",
+        "amount": 266.9442572367825,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "4945edb6-3c5f-45e7-9a42-a9584c9eaea6",
+        "amount": 652.4096303159903,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "dfd616cf-9237-41ea-a437-3b497c08b9ba",
+        "amount": 403.3407313707395,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "8c17565c-3f88-4b0c-a242-d8b91baf60c6",
+        "amount": 481.76979081823964,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "6133449a-7b13-4b14-a946-d3b7045eccd8",
+        "amount": 247.9760058943099,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "4b6f52f5-1c83-421b-a40e-719fa276972b",
+        "amount": 771.641377497445,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "b72055f9-64da-4df1-9d3c-1c77b4252945",
+        "amount": 91.65126600915997,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "50458281-3e6e-477c-8ed1-8562ef856ca4",
+        "amount": 426.44153737496913,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "e16a574a-1a1b-4968-be3a-86624c3943dd",
+        "amount": 17.39025986778827,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "a2652ee0-1b8f-438d-9534-9023885a7dc1",
+        "amount": 28.60569964179767,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ee01fc8d-c592-4962-8b32-11cfc3451b89",
+        "amount": 599.8709850270403,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "ebc672c5-9637-45d0-9f0f-d6797c3a29c8",
+        "amount": 247.67323533324725,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "69c39226-659c-4ca8-a475-58a46c2f6904",
+        "amount": 86.59914348744333,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "3710df96-ad66-4242-ac66-09fcac3af283",
+        "amount": 112.5943907939826,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "40f8ab57-31f5-4c7e-92cc-ad7c07561874",
+        "amount": 0,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "38e3568c-634a-444a-bd18-910b0d660b3a",
+        "amount": 7.515280950238513,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "9078b0f9-c52d-4105-aea6-beeb7599f95d",
+        "amount": 41.884180330118014,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "d553159e-c332-4c1d-b93b-8dbb53954569",
+        "amount": 398.95255542461297,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "318c95ea-9267-4870-af20-bf789f1b6760",
+        "amount": 10.182477119456623,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "2adea95a-5618-4de5-988d-d6f9af0bc17c",
+        "amount": 210.71995057974124,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "dd61addc-39e7-4e27-8b21-7e3a2d93b7e5",
+        "amount": 166.90666418734145,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "dba2ddb6-0574-4ce6-a12c-8912af7b62fa",
+        "amount": 769.1665787339884,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "317c9c58-ba9c-45af-a2f9-e90dff22d055",
+        "amount": 472.6578050769109,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "6d2c66b0-d0cb-448d-bf59-cf7bd225e44e",
+        "amount": 82.75053234646207,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "f6eec225-12c0-4918-8820-0de37e29811e",
+        "amount": 354.75049415365146,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "eb42f3d1-7f59-458d-8132-621b0638d9d2",
+        "amount": 312.3320947895364,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "715abfab-7bd6-4274-9362-fc0afd3b9ed9",
+        "amount": 386.5451877157799,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "7c5ac5d4-b20c-4c14-a8bd-d384e7419757",
+        "amount": 312.0719831788486,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "e8305453-80aa-4129-9031-ea98018082e1",
+        "amount": 613.0819610522566,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "4d21e838-2a19-439a-b113-b4633f00ec9a",
+        "amount": 417.3404067689139,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "4f7676dd-e2be-4ac8-86df-2915863dfa83",
+        "amount": 341.72847730359143,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "c06e2962-faa2-4272-b19f-9ca751f6fe92",
+        "amount": 540.3912987073292,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "71efff3e-5002-401f-bf2e-cc69548f39bc",
+        "amount": 5.202421093660671,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "21611447-dcff-4170-9508-d98afadccd3b",
+        "amount": 267.52754422434197,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "0a76129d-7ffa-4d8b-b69c-8e8b450f2b23",
+        "amount": 176.59890407857003,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "34828134-f6fb-4052-8205-8f3446dc4fa2",
+        "amount": 347.45974940636114,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "815f2ed7-7744-4931-b728-5c3384dab7c3",
+        "amount": 542.8535335079044,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "cd700605-346f-48c7-abd3-528ce51aef89",
+        "amount": 102.47919820697952,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "013f5160-3f50-4f23-913a-37411b92ddfe",
+        "amount": 86.06230776840798,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "84e87572-8598-4585-a532-a682d3b19ea1",
+        "amount": 305.08445388316176,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "fbcf0047-2524-473c-86ed-48ced2228705",
+        "amount": 132.02117164556026,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "1ef45e83-2f5a-4848-b5e1-0bf98955aa06",
+        "amount": 288.1146464667215,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "7b0822df-3f74-4acc-8471-40695c5606d7",
+        "amount": 834.8912109481822,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "a4bfa9fb-d091-47da-966b-5be7b79b6f37",
+        "amount": 5.982658488828941,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "2bc40375-1b49-4596-97c9-cb6f8b19cdb6",
+        "amount": 432.0513864311803,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "38436d6a-143f-4673-b86d-01feff2daad3",
+        "amount": 598.733677476647,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "dec8b7ff-a265-4127-8fec-e638114f506c",
+        "amount": 14.937989273970462,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "6df6f25e-af42-475f-a6f7-669395a1a0ae",
+        "amount": 94.96090318173636,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "2769ca84-c3e2-412e-bbaa-8bb016318ae9",
+        "amount": 573.4489086273302,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "8dbbb5ad-b30c-4d21-91ff-052066399a6e",
+        "amount": 86.69219911288782,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "e371992f-1aba-4d62-a3fc-a15e0d6054a4",
+        "amount": 47.27199808663561,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "347e44b8-58c1-473c-be42-5c4b37cc857f",
+        "amount": 126.99008149282707,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "a763456e-c540-4202-bf36-241b245e3be6",
+        "amount": 546.9143280733209,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "86218466-185b-4699-a2c5-b714f52b0248",
+        "amount": 61.98740138254543,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1abab64c-106b-4c1f-9613-ed5be7314026",
+        "amount": 206.54281470017187,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "83473729-9f68-4ca4-89c4-be16b0363333",
+        "amount": 5.846912979492025,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "d2895f51-5ccb-449d-8e1f-91fb78dfbfb3",
+        "amount": 75.6291598503853,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "052445f8-55c6-4c29-8ca5-701e112b60ad",
+        "amount": 102.19868402145183,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "a050623c-6317-496e-8318-6ea727563501",
+        "amount": 178.3567935039351,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "c305a9c2-a9bf-4093-9351-889f57a7a656",
+        "amount": 16.539658391342225,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "7547129c-6c26-4892-9c12-bff26a43cd18",
+        "amount": 277.10646168606945,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "2aff4d89-46a7-4194-8105-a0d3a30ac9e5",
+        "amount": 26.92511741918507,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "e4bfbbf5-9219-40a1-983c-63e656cdc9ee",
+        "amount": 218.09185534563193,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "d807761d-bb33-4595-a146-e95cd84f73b0",
+        "amount": 156.48473689056814,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "2ded2f71-e405-4ad3-be92-64632f8fdf62",
+        "amount": 121.3934502654439,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "beceac38-4ceb-42cc-96a2-8087b110206a",
+        "amount": 720.1124886252356,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "74908607-ce29-4cb3-8e00-68336b62024c",
+        "amount": 196.45331891021826,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "20bf8790-092c-4d9c-aa5d-f15afe06454e",
+        "amount": 295.3664144006326,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "d1013e86-a913-4f23-bf6f-1085fd05a7be",
+        "amount": 121.19509753944578,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "fa2e633e-376b-4cf2-ae44-8bcd4f036a0a",
+        "amount": 604.3581237175174,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "02d7bfac-d855-427a-ab91-56d01554eb36",
+        "amount": 126.98658998496384,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "57015a6c-9574-4bd4-b6df-63877a31c4e8",
+        "amount": 152.26396237352895,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "54b6cc09-aee9-4857-8489-3e3d853e6a03",
+        "amount": 136.64806281617368,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "27747479-41b4-474d-81fb-3e13d328228b",
+        "amount": 137.70455874259721,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "ece44984-c77f-4cb3-a785-d019a4b3012d",
+        "amount": 345.03813360980615,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "a74c4cdf-32ee-4894-9a56-9d6f61994f07",
+        "amount": 102.00846718687664,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "74a229ea-1658-4331-bb0e-c13d58d862b8",
+        "amount": 621.1038300427012,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "f52b2ff9-836d-44ba-8c16-5d809357a5e7",
+        "amount": 362.95655248516374,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "1d1a7edb-d11f-4950-ac32-3f71719cbf4c",
+        "amount": 647.2994355207094,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "2ba04b13-de32-4039-ae46-90b31a4e9c9f",
+        "amount": 675.0753293542278,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "7000e2a5-26ad-41e9-8314-3fedc7c14c32",
+        "amount": 587.9416933226022,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "3cc75625-d249-4dc1-9da1-a34734a56762",
+        "amount": 255.79776616756672,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "98c69d88-898a-4f57-871e-68da91ec9609",
+        "amount": 77.57516754824736,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "4b658f90-26ad-4133-83e5-4848677a184d",
+        "amount": 2.666115816567598,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "ef587da0-2671-4d5c-acf4-277a2005eb95",
+        "amount": 75.83195660447643,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "615967da-c082-4d79-bcac-c6e0445cebee",
+        "amount": 169.9585913918861,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "4ef11efe-bbd6-48d7-96b4-f5f68383d3d5",
+        "amount": 158.62233451776592,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "a569c663-b0af-486c-bd7d-ec242c104336",
+        "amount": 121.24099204817526,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "df5478f1-37b9-482f-a406-1701345f3152",
+        "amount": 607.8972174687904,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "35f0d4bb-7860-4843-b99a-02144417a18a",
+        "amount": 54.86697706344841,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "99b3bca0-be57-4f5e-b263-77b60bcd54cf",
+        "amount": 342.93218592964394,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "f1041381-c320-4e57-8f3f-6773a3b671cf",
+        "amount": 333.7709009310524,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "80b44b05-f0d1-41a8-9ed3-ea0834052d20",
+        "amount": 171.26321910804282,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "578aea72-f207-4b14-b6e1-cc4699c85a66",
+        "amount": 181.72034056182005,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0cb21d2b-46b3-4a64-9da2-079d90fff10c",
+        "amount": 275.8398676121413,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "58c89b80-5c9d-45ed-add7-390cb30212ae",
+        "amount": 298.21977004317716,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "a94baca4-167c-48bf-b20c-0be91ea73a7e",
+        "amount": 0,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "9c85e7b6-22a6-4d32-80b0-f3e512477b2f",
+        "amount": 390.40634179059043,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "85a484e2-84c8-45e3-8d9d-0fa1f570245e",
+        "amount": 503.2113756406147,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "0d48160a-f907-4b9d-bcd8-7b10b1983403",
+        "amount": 487.3286425835536,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "302cb4fc-b8a5-4c68-adbc-27269bc8c615",
+        "amount": 134.28519360319595,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "25ccfea2-6683-4150-9357-9fb1fc71033b",
+        "amount": 43.61243759108359,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "51b99108-21d6-40d4-a8c1-1de6ceda8b18",
+        "amount": 309.5504376140476,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "f1a6fd8f-c118-4f14-a5e9-0132c8cc4354",
+        "amount": 134.2740212480901,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "52e812be-8647-4e5b-af30-1dc3d2771115",
+        "amount": 551.9541312223339,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "6d60425b-194e-4dd4-9098-4f84e7157bf9",
+        "amount": 90.37029364195806,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "9a9558df-167e-4c00-b810-9169ad263573",
+        "amount": 538.7232805298429,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "3206a9ae-5c9d-4010-813a-55b502030e2b",
+        "amount": 226.47073118257802,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "d01d06bb-c37e-4e49-a344-f033e2f6dbf1",
+        "amount": 384.9843664532225,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "de45c733-e96f-4eb0-ba8e-a134a729bf15",
+        "amount": 9.257990003652843,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "4ad0f76d-ccb5-41a2-b858-17422a8aed95",
+        "amount": 91.01022259932394,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "2664c56e-27f5-448c-9010-3fa92a624f57",
+        "amount": 365.0027175303707,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "fcf37912-aaef-4446-8671-a422767dc11c",
+        "amount": 626.1063422460081,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "26c80b68-aff6-4eba-b472-d5e6dfdb0de6",
+        "amount": 131.4285460954032,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "3d117638-7b9a-4c80-954d-b0044f25a099",
+        "amount": 70.52052624647322,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "30a03e98-135c-48b9-8f13-481ef62071c2",
+        "amount": 707.7058897251213,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "28e59d46-39c0-4fbb-827a-d9a999f88d4e",
+        "amount": 3.380670357951103,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "ade652d2-987b-49b9-867b-dd530a6432ec",
+        "amount": 525.5019032344308,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "8eea1968-b8d1-48e8-b2c5-a736d20b6eb8",
+        "amount": 212.2082540288884,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "2df7b7a6-bf80-4907-a7f8-fe9f6ee07304",
+        "amount": 431.26607580747225,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "0aac57f1-b1f5-4f22-a56a-0f744df617c8",
+        "amount": 26.479594788805386,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0a5e0acb-5b4e-4f0a-a35a-5033ed454b49",
+        "amount": 357.11315787717325,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "2cc15df9-c1b3-4f5c-8e69-0e73655ab916",
+        "amount": 3.033186394122759,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "fe56e6c9-ada5-48b1-921f-650e5f4d4940",
+        "amount": 194.90854102683267,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "cbd8d582-4fee-4a32-a029-b844137ebf48",
+        "amount": 27.390455371029333,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "213b6c9e-e7b2-4bd6-9a65-ee9997b651f8",
+        "amount": 43.96728812391173,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "011c0030-4dcc-48d5-aeff-091800eb7a15",
+        "amount": 398.0351561297571,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "289d161c-3b3b-44d4-b166-455ad8d13c99",
+        "amount": 273.5246671941593,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "31d8db2f-57eb-464b-bc74-019791a60c26",
+        "amount": 428.6934383328902,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "65ea8a48-5052-4d57-98c8-7979f39323fa",
+        "amount": 21.170282960186942,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "514784ba-30ce-42d8-95c7-aa55460dd393",
+        "amount": 531.5120076339459,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "198786a2-2d8c-4dcb-83be-0ea14aeb2652",
+        "amount": 256.4032096955946,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "2d8c709b-c8f1-4259-abc9-184081dbfb44",
+        "amount": 10.679175505555245,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1e37fbdc-85ae-468b-83ac-0b27b01e0665",
+        "amount": 158.60405401020222,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "56e868b5-8f74-490e-b173-7734f5075975",
+        "amount": 201.56574038473096,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "5acdae2f-ed34-4fab-b497-5746f0620b40",
+        "amount": 81.67305863053807,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "4a80705a-79e2-4497-a64b-571fadc3c72c",
+        "amount": 80.89498247099819,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "41e39c4f-90a6-4a30-98c0-eb84bde19f5d",
+        "amount": 29.73837950950868,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "43c65944-e7fe-4252-909f-d971a9b65738",
+        "amount": 333.49630538176973,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "379b13bf-61f3-47fc-9673-63bdb6a7720d",
+        "amount": 427.98045669685064,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "8a25acd6-0615-4ac5-b287-909f8e30aa14",
+        "amount": 79.75061732117389,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "6a6782d7-602d-488f-a981-b2f8d7e4b647",
+        "amount": 141.1540273694,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "571f54d6-060f-4703-8c87-c5b8cd4360df",
+        "amount": 1.4767790470509878,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "7eb829cf-74f8-4b05-a4d2-1b28f94caee3",
+        "amount": 48.88444484510711,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "0ce9819d-6c00-4bf1-b843-568b9475275c",
+        "amount": 142.51015886007139,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ab3634e8-0152-4985-9277-4d75a0bb5d83",
+        "amount": 71.17515332491443,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "b421befe-b3e0-45be-a6aa-0bd58d6ba789",
+        "amount": 105.43645659495732,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "281c9ea7-1d17-4ca0-967b-4ed50c09634f",
+        "amount": 366.3430421402297,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "afa60eb1-0ea8-4365-9a92-cfb610f79a91",
+        "amount": 275.1515197808913,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "667a1fb5-8df7-4a6f-bff4-c4bf69a9db67",
+        "amount": 76.09900621874249,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "4ab97ba1-f082-4aea-aed8-8664c60e0b48",
+        "amount": 316.48466347171575,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "8c1385f7-7eca-4f69-8e1c-caca0ed9fbde",
+        "amount": 338.98299584411365,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "96bfb5b3-f79b-4429-aa0e-747ae5811b41",
+        "amount": 356.86733111951855,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "308e3b50-53c8-4f8e-95a9-26a07d668aa3",
+        "amount": 417.0571186754016,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "c4e06dc7-5678-4930-b0b6-3814d98d8a93",
+        "amount": 125.64292129483668,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "aae73bcf-2d00-4a50-a163-c2d83360ed2c",
+        "amount": 693.2119588115153,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "30f799f0-541a-424b-9786-23c7706e7dd2",
+        "amount": 44.067923011921984,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "cc2272d6-1923-4936-9337-f8a80dd1052f",
+        "amount": 292.41118459994976,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "1c473552-3561-42e4-9dcc-999211dc8009",
+        "amount": 686.4105373826669,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "684af881-4a04-43c8-a6f2-6a96dae51a45",
+        "amount": 44.965651919465685,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "d4998af0-8336-459a-a208-4adfd57e11b1",
+        "amount": 860.283628012167,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "30fde5ba-81cb-4541-b5e2-e33afa7fd81b",
+        "amount": 71.41036011325079,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "e8c8d23b-152f-495b-b4e2-386fbd62111f",
+        "amount": 474.17768647924186,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "32c4d51e-a1e1-43cf-8faf-e0e289cedf45",
+        "amount": 312.9770124521966,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "0eb3fef3-d933-438d-9185-394ef1869c94",
+        "amount": 380.13423135645394,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "3e793083-8301-4b95-abb7-c72e14770a20",
+        "amount": 348.9013686359207,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "6acc2587-7390-46b1-af81-bc404c462e97",
+        "amount": 38.910968240083186,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "75b96886-50ae-4195-99e8-90e877ed2a12",
+        "amount": 4.609021136549567,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "f88727ac-ed54-4fc8-8f72-2332d371de63",
+        "amount": 138.97766834389142,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "915c71d8-96d5-48b2-a9ae-f394a8ebd051",
+        "amount": 157.78988656114487,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "cb85241a-ee10-40df-9927-ca6c5490a3bd",
+        "amount": 42.02888841970248,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "bfa7f767-b681-4f57-9bb5-fad1c2368bca",
+        "amount": 10.653738366147524,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "ba4d10f7-dd06-482d-8889-9134d7172424",
+        "amount": 64.6700358378451,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "f552baa7-6c82-4cc6-911e-47453f56c636",
+        "amount": 148.52567726828872,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "16de1baf-d9da-43f8-9527-af46ee4a710e",
+        "amount": 254.17909442461226,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "c1e2578b-9080-4be2-9a92-082a3c268a2b",
+        "amount": 104.05843713140135,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "a580cd51-e752-40bf-8ef0-aa64d1d476f7",
+        "amount": 243.88218788240994,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "c07e3542-c49d-4388-b788-1ded5e0cb8d1",
+        "amount": 59.82868193127357,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "a587c549-d132-47ed-8f13-6a494ebe1068",
+        "amount": 175.74246784230277,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "8c599caa-ebdc-4ec2-9771-7c48340ba0f3",
+        "amount": 228.96001252659903,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "e44e082e-4861-4d7d-b76c-4c5cc443266e",
+        "amount": 101.43294258861603,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "bf8419c0-f6bb-4453-8a44-66bd8f92ffe8",
+        "amount": 158.04157851798936,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "50f34984-0edf-4952-9e2e-44fe04c37a07",
+        "amount": 15.950902465821105,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "48e47de0-32b4-49b8-b2be-83eb371cfe96",
+        "amount": 303.25501794507096,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "2a7dc037-c74f-491a-a80d-3192cb7bcfe5",
+        "amount": 285.72960474147885,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "173ca4fc-eb7f-4832-9bb0-92638f5b5d45",
+        "amount": 195.28315762552862,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "fc86f3d7-18e9-47bf-8cb0-b85ce5bf5108",
+        "amount": 69.32734471520561,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0c5bd021-7a6d-4fb9-a8f7-f0dbd34418c8",
+        "amount": 241.82507997571665,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "3650284b-7346-4460-96e1-2bcc4ae1511b",
+        "amount": 717.7941139472623,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "2cdecbfb-b36c-4173-96b7-bedc0abe9244",
+        "amount": 237.85054367757346,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "7855ad0f-702b-4925-ab1c-7f09e9ca2bc1",
+        "amount": 926.6998053158977,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "d4aad51f-5bd7-407d-87ca-ad14a909b02a",
+        "amount": 101.95075097154768,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "a9a81522-1d32-466f-b979-b7d3ba27a5f8",
+        "amount": 473.8651289254994,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ae1d6e2f-164a-4b57-a2bc-3d78f97d96da",
+        "amount": 60.49139982229036,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "7faa9e3b-401a-4b0a-8e6a-12c97762b20c",
+        "amount": 111.11254292412556,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "338d2462-a333-48d9-9282-5e3d61277959",
+        "amount": 780.808724956515,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "58290bfe-1f6e-4c1e-8bee-4161ad0c2c8e",
+        "amount": 162.93359705870014,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1bce6a4f-b994-4ad6-b69b-c8680e9329fa",
+        "amount": 210.34998415217,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "976ac99e-6bcd-4114-bfd2-039aba13ae7c",
+        "amount": 716.1423983412095,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "c0a304f4-5b5f-4d96-a80b-a942ffad20a6",
+        "amount": 223.87447477543105,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "402bcb87-77dd-472f-b138-8dcd58a6bf89",
+        "amount": 258.44077741646174,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "af690793-8e05-4975-a30c-c8c1ca713d1c",
+        "amount": 22.363644362906737,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "e928ec8e-f893-43e2-a2bb-f590e73445e1",
+        "amount": 25.732025752199345,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "e7a16c3d-bb52-4448-904c-eb9ba1667f4b",
+        "amount": 656.8170097685979,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "2b964a4e-faac-48ca-955c-0130658bb84f",
+        "amount": 234.8775459500874,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "eae9902b-c67a-4a4e-8dd3-ba8873972aeb",
+        "amount": 24.12345534708685,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "df1b0ce3-da4a-43fb-ab1c-da49444b01c0",
+        "amount": 3.9450195424319494,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "aabdd983-68da-421d-bcbc-a347b4567e85",
+        "amount": 95.9440374135108,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "7fd3547f-3ba0-4882-b03e-0760a64827ed",
+        "amount": 530.5889338782912,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "cc16a62d-3413-48b8-993a-30570ec27413",
+        "amount": 451.93401987301763,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "80c68600-dae7-43fe-b959-87d283398b17",
+        "amount": 121.33095362327083,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "3403e92d-6c6b-4214-bff4-15b3602ba248",
+        "amount": 381.2923956520242,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "50d7ece0-7527-4b00-ba29-c81b9faee0b3",
+        "amount": 115.77865789747035,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "8403dcee-4df1-44d2-98db-3d36e5718116",
+        "amount": 442.450180324405,
+        "comment": "",
+        "date": 1632755177924,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "34ffe5cc-8cb1-4eed-8bdd-5638844031e6",
+        "amount": 4.208325159239644,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "c4c6bb52-476b-41c2-bc39-8a5b93ec5cb4",
+        "amount": 456.4387163835848,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "154e4686-3594-4d34-8b5c-a4c7b6c9782d",
+        "amount": 132.2019033766972,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "79f54b8e-573c-4e7f-8dae-97ea800d3b5a",
+        "amount": 170.1685465340134,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "addea533-0448-44c2-b178-1c5a16c772f4",
+        "amount": 218.30295118486822,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "1933423a-3c06-4422-91da-7eb1eba104de",
+        "amount": 594.5020471484785,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "bd7fc4e3-c762-498f-a541-a1626cef665e",
+        "amount": 42.60387256591719,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "f1c68178-821f-4808-84be-3b4028aa967b",
+        "amount": 715.3954882500334,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "145750fb-831b-4615-9f63-413906d81bf1",
+        "amount": 289.7182585585897,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "7f6a715a-3e10-477e-b154-10adb4c29e30",
+        "amount": 197.7317436843726,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "1aee1e8f-12a9-4de1-81c0-c02aa55adcb0",
+        "amount": 378.8931779327519,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ab20fe03-2930-4e55-a6b4-268e74f942d0",
+        "amount": 396.1837688260585,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "659f028a-cce0-4cf8-b7d9-3ebc95677adc",
+        "amount": 734.1017514891753,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "3e7cfce0-2671-471c-8704-915696f4bd64",
+        "amount": 85.3974742257856,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "6940cb8f-a6f9-46dc-85e9-06d2161c3151",
+        "amount": 522.2172489836315,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "a6878c2f-2d08-4539-8ddf-f9c9080b6d8f",
+        "amount": 1.506038696641342,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "7e1b350a-c9a8-49cd-b1b6-4e895a6f65aa",
+        "amount": 137.75111979695558,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "33de976d-2b66-4462-ad63-f2ff7d0342cb",
+        "amount": 5.552172746579877,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "aca69eb8-c5be-4a55-acdf-8bd70a4a66ff",
+        "amount": 22.714729945273437,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "60a1cd83-92da-4c14-9f21-7b5194949531",
+        "amount": 35.834932352549075,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "2af4ff63-ad73-47fa-8d53-bf9aba3c7e1a",
+        "amount": 409.21748995761834,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "2041d5b8-d6aa-4568-b400-3abb674e8eff",
+        "amount": 533.191131278705,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "4e59ea9f-0a4c-4624-a3c1-ca06fb580ad1",
+        "amount": 766.7026852504987,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "707419e8-35e4-4a6a-84aa-c9741428dddc",
+        "amount": 376.3829290634467,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "e484c798-f3d2-4ba8-a366-830dc61a9172",
+        "amount": 165.96445505315543,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "63d1cb76-6cad-468a-b3f5-5a78ca28a322",
+        "amount": 152.0199681661444,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "76c2a3fd-3db8-43e7-be60-87db17c686be",
+        "amount": 266.0509103051728,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "ed36efb3-a0ee-4699-8a90-465891ea83b8",
+        "amount": 485.1051713653383,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "e2a47608-f7c3-4650-945d-dc8fa37eccf0",
+        "amount": 179.6077083736139,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "05414c9a-404d-4cd9-9117-dbfc1ac1a14d",
+        "amount": 64.47057970814642,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "3056e9e6-6d24-48f3-919f-ba532d603e6b",
+        "amount": 2.2310959513340816,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "8e1de0bb-943c-44f4-8e2d-f12945bac5c0",
+        "amount": 314.36050558759376,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "0af710cb-f626-44f6-badd-472591e42f77",
+        "amount": 127.84700545712246,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "02d6d23e-58d1-421b-9a15-5f4a56128b7d",
+        "amount": 115.62742927765275,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "140807ef-100f-4c73-b654-e2a85184ceb6",
+        "amount": 125.14303022417572,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "a1703392-a634-490c-80d0-ac982ad5ec08",
+        "amount": 13.419383727354697,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "776728ca-1609-4b71-8fc0-a4524342d7f6",
+        "amount": 285.17560662395624,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "46852edb-cdec-4839-bcc4-e9147b852165",
+        "amount": 70.08497153283803,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "63475818-9da6-48f9-bb32-95f0393ec26c",
+        "amount": 9.231332773206397,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "399dfcd2-1f07-4f7e-80a0-f727edb19252",
+        "amount": 47.68771727797148,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "a1e24c17-d594-4262-8c09-f5ee7c29ac8b",
+        "amount": 137.20698898722395,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "657fe95f-4f5d-4986-b9f8-c214d7bfccff",
+        "amount": 212.45440469756272,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "774a0a67-40b5-4252-b68b-55323e470498",
+        "amount": 266.1555811825475,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "fee37c9d-a6bf-4bd3-b334-f84146b8e96b",
+        "amount": 418.260511734194,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "cd5f8412-869d-4a9f-bf53-3539f128ac74",
+        "amount": 395.0312326634366,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "b0b7cbff-d5c7-42c9-b7ff-0f1205f1374c",
+        "amount": 449.91062303975707,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "1f828329-92f6-41c2-b195-6f7f6b21ce5f",
+        "amount": 44.04085936889085,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "3cfa52f8-47a1-40cf-be74-57d8873d6f99",
+        "amount": 502.793398833785,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "b07a4d6a-891c-4495-8f03-bd05f5944884",
+        "amount": 36.55168776639894,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "06adff10-0c98-4fa9-82a9-2187aca938c0",
+        "amount": 131.61027060079002,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "de3c3ca9-76f5-44b7-afd2-dbe95b3a8433",
+        "amount": 17.89696181787378,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "e0418e44-e60d-472a-8d11-c54ef4b6ec01",
+        "amount": 446.6254314994462,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "4c9a5516-08ba-44bd-9fdb-20918c9a41db",
+        "amount": 160.27459413067243,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "d38d7043-070e-4139-a330-5bb905ec7c60",
+        "amount": 329.64261207323847,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "7fdebf2b-22bd-45ff-80cd-3812db7f1d5f",
+        "amount": 574.0403158339034,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "9dd5678e-089a-4724-8561-6ee0f88a2531",
+        "amount": 441.17504758006294,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "65ac4962-16b7-459b-ae2f-c06427022c6a",
+        "amount": 94.57692672478808,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "1897e259-67af-49bb-9acb-60317a8deed5",
+        "amount": 43.84112346970695,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "6d4c67e2-7238-47fd-89d0-8fa2a0de6d74",
+        "amount": 202.41835021879922,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "305f0dc7-8526-4bb1-8a26-e275aefab2fd",
+        "amount": 620.9703127443184,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "2d5ab95f-6781-4bc8-8b46-b95b2c54f163",
+        "amount": 301.5760466056898,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "604f9ca7-76bd-4ac1-9e60-4e2e7a6c1abd",
+        "amount": 298.2678968696073,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "65806acc-7c87-4098-af38-eaf0bc3586fb",
+        "amount": 658.9195688524395,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "7ffbea70-a3b5-4536-8fde-05785c932b77",
+        "amount": 91.6390529462079,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "6cd76b4b-e3f7-4be8-ba89-fe66fae59cfb",
+        "amount": 137.65830572563996,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "dc2e83b5-beab-4dbc-ac31-832e3b3e3b01",
+        "amount": 57.78912681627047,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "ef7aa27d-850a-4ed6-8235-af6d7b437155",
+        "amount": 40.84325758439872,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "a8332630-1800-4131-921a-a8c90e2bb575",
+        "amount": 56.4885463524209,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "cc7adb81-5327-4fb1-becd-97f2f44e8833",
+        "amount": 165.05599156600832,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ea708e6b-c45c-4cda-b88d-5d98ec44e552",
+        "amount": 50.2672417549354,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "fd0e1c92-dfa4-4656-b788-6ac13fb7dfcd",
+        "amount": 183.24094736415833,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "6d888b7d-52b9-4755-8189-eca59d180846",
+        "amount": 48.08243285827043,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "bac8a82c-2afd-48de-a021-9aebca5c1be0",
+        "amount": 448.62492787092134,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "b8b30382-f84b-4210-8330-eb3404f5431a",
+        "amount": 23.921909910822173,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "25ae77ca-52bc-4b09-b380-74756b38aa2b",
+        "amount": 321.5501188936189,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "dc1ceb35-25e6-478c-81ee-027937b90a0b",
+        "amount": 723.5120041267983,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "9f52366d-0b50-4c93-ac91-42869dda1500",
+        "amount": 162.99236491235598,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "0a5fe4dd-6c4a-4f86-9a3a-6f4030713fb4",
+        "amount": 203.76432265445467,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "052207e7-1082-4319-9cff-67fbbfddd90b",
+        "amount": 214.31708750966516,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "9ab2ef9f-78d8-426c-8192-fdb0ede6b359",
+        "amount": 331.3177403308491,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "4d7adac5-1642-44ff-a98b-9008e661a87c",
+        "amount": 60.50646812694916,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "3c95fbae-7a2c-4d7f-84cf-eb9500aa36e3",
+        "amount": 322.0366452614225,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "72712cf3-151e-4e59-b8b7-649990f0ef64",
+        "amount": 228.5939484372817,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "0f6cbea6-25ef-449b-b0bf-b054ff2f1b38",
+        "amount": 322.6482070063678,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "56badd03-c49c-442f-b90f-41d14fadd37b",
+        "amount": 481.69002022604445,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ad91cc64-8294-4f5b-9d88-346bbcb47e9b",
+        "amount": 37.65817893654115,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "2c7dd2d3-d52b-4b48-b05b-6079043f7054",
+        "amount": 8.77868213876898,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "2a144435-0555-4825-b5d7-0da1edea582f",
+        "amount": 80.3134155114397,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "764f32a9-f158-41f9-acd2-f8f1c1ae6103",
+        "amount": 351.4419638752588,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "61d908e4-b8c5-4a5b-a2f4-2097aae4c0f5",
+        "amount": 2.571395767621574,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "62cbd8e1-703b-4a17-b094-293bef1b34fe",
+        "amount": 143.25429016287626,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "2c7166b1-a048-4bf0-9814-12d44973436e",
+        "amount": 16.776169280501826,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "a193e396-8d4b-44b4-9794-ca14a5f9e517",
+        "amount": 185.52606693179717,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "69e9393e-b1c4-42a4-8f0f-6d19c3c7fccd",
+        "amount": 414.19245201919887,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "117a13d8-a8a0-41d2-8480-36cad759ad3c",
+        "amount": 14.376591422815906,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "80e0da76-a111-47ce-9c91-b3bac1bbe013",
+        "amount": 11.933223991081027,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "f2366359-72aa-469c-bdf5-fc4fda158654",
+        "amount": 120.52412649560736,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "2dea0a59-892b-4a62-a3f6-67661adfd2ea",
+        "amount": 480.5137903436792,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "41492aad-310e-42ba-8a2e-ca7458402f48",
+        "amount": 95.59017090016384,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "a97bac72-6c49-4901-8112-52f622a60954",
+        "amount": 48.78991632211726,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "72acd179-cb39-44ea-a4e3-6532a740d1e9",
+        "amount": 3.7573983031770437,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "e85a0bc7-5e5f-48d3-9e25-2347daf93665",
+        "amount": 36.90330963991404,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "4a07fe12-8fe5-4e6f-a832-bfcff2905c5c",
+        "amount": 97.63881913316638,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "98ad652e-7087-44f1-bee3-e5fd688f4774",
+        "amount": 152.20401058948266,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "3ccd44e3-f825-4266-a733-1260a22c2558",
+        "amount": 13.495302585099214,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "2dc123d0-6e49-4502-8aac-808d1bb8ef5c",
+        "amount": 13.43975066503545,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "5a1ac475-9525-4a1b-b956-e9e5db9eb5e7",
+        "amount": 59.7494212938258,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "40aa9e58-f7ff-48a4-ac55-4ac307b0a3d8",
+        "amount": 633.6356588945205,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "69b8c0db-5fa7-4de6-8f96-0b06d5f8057e",
+        "amount": 230.45887255795031,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "52c4661c-037f-4bd7-bc8b-ca1b2a7252d5",
+        "amount": 7.748667529770239,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "5aadf1ba-556c-4eb8-8847-d2a437de6423",
+        "amount": 630.1253658462642,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "c0cf7aa7-2c28-4e7f-b8a1-5c64e7c5fe35",
+        "amount": 199.85735008641828,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "3843b811-68ce-4c2c-a55d-a4965ab13da7",
+        "amount": 411.82127682549964,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "87fed876-61bc-4dd2-a1c3-0dc02b101943",
+        "amount": 108.35519552957099,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1a7e6b4e-dcf2-44d0-973d-1e2280c0c260",
+        "amount": 48.89816846975896,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "3cb99251-dfc6-40f1-9cfc-eaf992734ee9",
+        "amount": 140.3050796528197,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "2655c206-3de0-46c3-9f35-14f788d93656",
+        "amount": 609.0968418244279,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "0369548b-07cf-4db8-a949-20ed81e8e033",
+        "amount": 792.5245734515887,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "d675a4bd-265a-4fa5-8d05-cb612d1d37ee",
+        "amount": 14.923994389554284,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "7d11d4a0-e93f-4cf0-9dd7-55c0909c05d9",
+        "amount": 206.30126550594755,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "02b12f52-c0f2-4994-a34c-29cb2f7ac436",
+        "amount": 901.2413972010075,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "ba7537c7-4c25-4236-a0d3-c896ec104d4d",
+        "amount": 94.81446212723051,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "9e5db97d-e4ab-43b5-afc0-4eac1db5eac6",
+        "amount": 140.8143612550432,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "76b32203-ec1a-41b6-99dd-802ac2dad954",
+        "amount": 555.5691198473173,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "e0ead13b-a9b2-4708-8eb1-a5134d7d4aa6",
+        "amount": 98.56182069726782,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "5fcd2fdc-7324-4e43-b13a-ec7bfacfe8ea",
+        "amount": 177.58423504471935,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "266469e4-5cc5-4240-8685-33709704e388",
+        "amount": 11.865354378521538,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "3f2b4907-593d-471d-b94a-cc811231acc1",
+        "amount": 439.6526677205955,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "18f8a893-ba65-486a-8bfa-3148b7db697c",
+        "amount": 133.97554959906626,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "848a2a3d-6ab7-46f7-bc37-f030e2454143",
+        "amount": 417.2522376871763,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "c57fa19d-33dd-4399-a5da-46c172301a80",
+        "amount": 489.63959470934265,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "a07f1980-f1ec-41b1-903e-302b09529f18",
+        "amount": 55.04859295683329,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "e79a208d-0556-4e18-8533-27c35377ab13",
+        "amount": 434.89644036104204,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "6c6f779f-0df4-4ec1-8b59-54486fa9b36b",
+        "amount": 23.05215759079151,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "55ffa25b-68ad-4190-b5e5-b699fb8fdbd8",
+        "amount": 164.0552114071393,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "24daedee-e3e5-4b82-a987-4817fee6314a",
+        "amount": 124.27938368856464,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "830a0d19-d343-46b0-9792-ba6962eefec3",
+        "amount": 215.96561477019776,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "8a194383-d18f-4eca-8865-715fcfd3aeeb",
+        "amount": 83.545184659656,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "1a2f4c6d-4c5e-42e6-ac4f-424958bb9a0e",
+        "amount": 20.985225393574133,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "c42164c5-5278-41bf-8ccd-a2cf6f05a5ed",
+        "amount": 160.20398741291245,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "655244d5-f538-492c-98f2-edd358a4ac71",
+        "amount": 324.5889416448738,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "b85d91d8-b3c6-4223-8821-174b5b2b1a7f",
+        "amount": 10.497965839121065,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "e6bbe831-9674-469b-8c21-b2c6f2a2cca5",
+        "amount": 350.6436675652738,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "dc1f49ab-2bf0-479a-aab1-c628de81d4f5",
+        "amount": 172.0802064805218,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "320bde13-e264-4051-9f99-065ac4c9267d",
+        "amount": 872.1982444181455,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "fc0b4bbd-b104-462a-a4b7-d30e39eed8de",
+        "amount": 199.24714832462175,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "08ffebc1-b209-4734-9526-1ddf157616f3",
+        "amount": 141.48400115996773,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "8cb0c0e5-9dc6-45cf-a635-e3e270785e6b",
+        "amount": 218.50721101798507,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "2a2c97c4-4807-4251-95fa-ca7ce496d19f",
+        "amount": 626.2348927132839,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "2ad62ddc-52ad-466d-9ad4-f8ce3f01ff40",
+        "amount": 37.44692867161014,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "afe2cfb0-2427-4370-9822-455b1ec0f4a4",
+        "amount": 527.1007369605807,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "fff67ce0-ffbd-4474-ad87-d8844a1d759c",
+        "amount": 240.41483426595667,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "39923c71-3041-486e-9edb-a10592752416",
+        "amount": 227.12351601017716,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "647e57e5-1b9c-4e99-96a3-8e5400926314",
+        "amount": 46.079037242384246,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "7d8238dd-4c78-405a-849d-6d9f1cde63cf",
+        "amount": 278.39742318574787,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "ac05e52d-5ca9-4298-84a2-e8d8153abacb",
+        "amount": 102.93705518402112,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "28443190-6be9-4c70-b9f7-55f4fbde76c3",
+        "amount": 317.25199090012393,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "092edb89-6d15-4a7e-aa9d-1a607b62dd0d",
+        "amount": 12.108260730649164,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "eb8d6992-9b50-46aa-9e5e-4319ffc92d0d",
+        "amount": 40.99724864906004,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "9c0885d3-4acb-4dbb-8669-0b64103ae6f9",
+        "amount": 219.53459260795114,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "0e976283-aad1-40a5-b6ce-5649ab5db068",
+        "amount": 852.4847942530347,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "738aa569-c5c9-4cba-b18a-ad6243d1a0a9",
+        "amount": 177.19397157025713,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "f6a4572c-f267-42b9-8311-b089629159be",
+        "amount": 368.4623976247634,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "2c17470a-a8e7-4511-b521-b02068ad2643",
+        "amount": 217.95099739399558,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "d8ba663c-15ef-4102-8908-983b436bdf25",
+        "amount": 534.7492203297534,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "4a8b87b2-55a4-46f6-9dfa-0a42f22c8269",
+        "amount": 342.8303655937999,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "413b4717-6fd9-4276-8ba5-75deea87732f",
+        "amount": 227.82932143455326,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "b2173b98-6c10-4a4c-90ea-48487351cdb6",
+        "amount": 156.4473464881967,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "d25bb20f-cbcf-4a72-b9c9-11aacf40a4a1",
+        "amount": 337.12616101147455,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "1dc54576-620e-4963-866c-b93501f16050",
+        "amount": 688.8374019511263,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "e4ce2169-6c15-42cb-9734-80dc00d9dac3",
+        "amount": 194.33730545913158,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "e6651f90-40a6-45ff-be97-1b7923faae67",
+        "amount": 70.41307393267824,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "5ef62172-6fca-41d0-baf8-b3a2fb8f4df2",
+        "amount": 225.0338521494717,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "1d6331ac-e719-4293-b11b-3dd388591a17",
+        "amount": 134.15855787742285,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "a0d304ca-baea-44f0-8fd0-b7d02dfbe4ee",
+        "amount": 611.2764655352788,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "97d0c5eb-dc56-4631-91f4-1c1d6f591436",
+        "amount": 109.01885861304204,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "567ac28b-936b-404c-b0c9-bcfddb380609",
+        "amount": 291.5256490346333,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "3ef96319-590f-4fb7-ab95-ae88ee6820e4",
+        "amount": 175.69756336307438,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "9431e514-14bb-44d5-82db-820994f7f0a2",
+        "amount": 247.88675902311456,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "b9be94ea-4f18-4c8a-85a6-0cb022a87258",
+        "amount": 864.1649577495918,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "8dbf709f-ebea-4513-a8a9-84b9882afcf0",
+        "amount": 22.123209291431415,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1bbe5fb9-e14a-4ff2-82ca-a8d4514bb415",
+        "amount": 209.58677842847723,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "95f25743-7f34-4854-b05a-c1c1c5440da3",
+        "amount": 280.07722988765937,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "ced6fb45-52f9-49af-b735-9c3dbda34d36",
+        "amount": 379.9305426062748,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "9c7e8cdd-9514-4c51-a7a3-888c8b58661e",
+        "amount": 749.8193911645774,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "2fa0243e-477c-468e-bedc-fae765de0138",
+        "amount": 82.78666277024477,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "4cdb2618-3f61-440f-9b5d-2da3c49e8933",
+        "amount": 413.4505560588195,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "7848da4c-25a6-4319-97a8-eda255c16e47",
+        "amount": 337.1142017347211,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "3b1b13f9-bb75-4de8-82c2-6d32717274ab",
+        "amount": 3.083179762900924,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "a15bbd84-a366-45a7-9d70-5cf895de78ec",
+        "amount": 819.6133927994448,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "8bb0af9a-d523-483e-af91-a0004ef38f45",
+        "amount": 261.7582450537967,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "fe865488-c962-4669-b5e9-e065f531e801",
+        "amount": 219.2911418762063,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "2f394ee9-a256-4a91-8213-44dcda6fff6a",
+        "amount": 338.18872322829543,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "2d4c6ac0-a808-43e4-a2fa-9213b5c423bf",
+        "amount": 270.40613904903944,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "deddf204-dcbb-47ed-837f-3f96bc11e48e",
+        "amount": 51.966320222472426,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "c9e002dd-4a0a-4ac1-a521-8f202716c9d4",
+        "amount": 80.10903940302872,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "977c5139-6931-4d52-88a4-3c6791e9c070",
+        "amount": 111.88416193934967,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "782e7640-7f83-400c-b70d-59e9c5ffecf8",
+        "amount": 16.28640676589043,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "87e76879-70ac-4c24-be04-daa0b0990625",
+        "amount": 213.34928596544367,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "13147783-2f98-4f65-85c0-2e8f2105da3f",
+        "amount": 59.056559999714096,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "c5e071a3-42c3-42df-b9be-14a72b7ce110",
+        "amount": 21.924810996112818,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "6ca5ddbe-d795-4f22-8457-f1ed42a96ce6",
+        "amount": 176.11263131668173,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "2ef7a943-59b8-4129-a5f4-48429bd6e837",
+        "amount": 133.68524985920376,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "d576022e-e7d3-43ae-89ca-e9eea92093a6",
+        "amount": 12.550624000138589,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "86a03605-3920-4b93-ba46-06e2ba33f53e",
+        "amount": 794.3342311029004,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "437ddab1-8f6e-470e-a256-e1542fbd1c63",
+        "amount": 49.467264110673746,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "0063035d-3ab2-49ba-ac2b-e2071ba012e3",
+        "amount": 11.687190000362099,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "d2deaf3f-e9cb-40e4-9f3d-ffdd25df7e29",
+        "amount": 321.13305977461107,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "875b4caa-378f-47ee-93a1-65590bc7b50e",
+        "amount": 53.07918694280771,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "5cba2a69-11ef-418e-9f58-8210c8f30b3d",
+        "amount": 207.14344271244013,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "5ed602bd-9462-4791-ba5f-1a870eeecbd5",
+        "amount": 194.8895599841414,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "a6078b20-9a00-4a60-bf9d-2ad3b9284fcb",
+        "amount": 251.56819702872795,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "2150c990-d5a6-4487-835e-db99b2a54b64",
+        "amount": 166.45611924073643,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "2622e881-d682-41f5-a0c7-25a4bf3d0e84",
+        "amount": 319.66036391137766,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "448815bc-a9a7-4d19-a8a2-01782df9231b",
+        "amount": 104.51651706850717,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "81fe658e-0b1b-468c-a296-c9855f71d6f8",
+        "amount": 4.13807525274369,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "b0e7d686-2da0-494f-8898-7fb93df83b97",
+        "amount": 172.4125566831436,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "e0855978-8fc5-4fcc-b3c0-d73830a1f47b",
+        "amount": 130.7570778949484,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "ffdb6227-4096-4468-8ee7-a3b369f17d2b",
+        "amount": 39.88887936236523,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "57f56a43-77ec-4cde-ba56-3eb4cd7573fa",
+        "amount": 483.3218461528149,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "4f31fcee-5669-46cb-ba78-3535bcb52779",
+        "amount": 520.8429116198703,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "70eff61b-e8c0-4268-9e08-4c6e8435f4e2",
+        "amount": 57.91490139224691,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "a63c4cef-5b8b-4b91-9710-300e2e5ead1f",
+        "amount": 161.78168447925464,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "59d57fa7-9a1b-46b3-a69e-81abb9c46b66",
+        "amount": 326.550629142121,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1b90fcc0-8c99-4449-a253-0bc93c918c38",
+        "amount": 163.93266469420956,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "358f594d-b432-4368-a767-69ed3588bf0e",
+        "amount": 242.46585108911157,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "66035f9f-1f6d-4502-8197-e27d5acf9e1e",
+        "amount": 174.76984470534646,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "3d9a1970-173b-4b5f-807b-355c521f24d1",
+        "amount": 22.018794397406857,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "890a43c2-8f64-451b-871b-4c84df9c152e",
+        "amount": 72.79499002418115,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "b7dacb8a-173a-40f4-b0f4-7265d5039042",
+        "amount": 41.74665647392089,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "405a979c-77c6-4e23-af05-078a858d5f4c",
+        "amount": 24.07820273444624,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "050ed3f3-85fc-4b86-b267-5cf3f9635c18",
+        "amount": 386.2751049561843,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "68faef2a-634f-41ef-a202-fbbd09c967e8",
+        "amount": 106.71054897591547,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "f25a7587-80e3-460f-a3fc-e50ba2b4aa1d",
+        "amount": 494.60621391225817,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "4be65428-ec25-4cf8-b5ad-69e030656b2f",
+        "amount": 140.1699080764766,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "f4e7da89-2d3c-4095-af94-0d13bb2d6f29",
+        "amount": 246.426031877475,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "2d6f4e0f-abd7-48a6-adb2-6e5d0ffb7cb8",
+        "amount": 32.00206311281346,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "a2a9010b-7ca6-4240-95cf-930b70fdbe56",
+        "amount": 500.49315217196676,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "27827f2d-fbdd-486b-ba83-ab8a29067348",
+        "amount": 192.7472075700819,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "a2faa594-ad83-4e49-b9f7-44db06485183",
+        "amount": 722.0108535467975,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "c61220bb-415f-4f5f-9d8b-7b11f966d1ee",
+        "amount": 80.76246672354262,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "43cc2ddf-78bc-46e8-b8a3-91e825c6b9f8",
+        "amount": 445.72856743356226,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "54493452-c3df-4693-838b-99d116c1f043",
+        "amount": 266.7581642937219,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "3b4fffc8-5f77-47a9-a008-25b3e198f905",
+        "amount": 440.1132354187568,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "bb852427-ece2-4ae5-80b0-595e674f2231",
+        "amount": 0.4283196668898146,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "a555aab6-cd66-48de-81a4-8a24a583cd1e",
+        "amount": 106.98900138773354,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "c8a8740f-1692-4542-a746-24c526485568",
+        "amount": 16.92346839920552,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "d0f353dc-5083-40f8-986f-265bfbb251cc",
+        "amount": 1.3490238441748246,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "329e20f8-47e9-42ac-8f6a-c5c615c0b51a",
+        "amount": 194.65075998524765,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "334d087a-6364-4ef6-8aa6-b0ebc6e19d81",
+        "amount": 41.761203811425524,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "5b5a0620-8ed2-4203-8156-e4f5ec39d748",
+        "amount": 629.12138032202,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1ed6ef9f-0bbb-4667-85cc-093e51e4bcd7",
+        "amount": 289.6098624247786,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "fdfdd02f-d2af-46d9-af29-6489f9411abc",
+        "amount": 227.1934584053088,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "ea1b2082-166e-4b6d-b366-a442c7082fa4",
+        "amount": 16.03584913753277,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "d4400413-cc0d-40bd-a581-9895f66f8b1e",
+        "amount": 71.60594117756736,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "d2b7bb8e-7dc8-4d1f-a23c-713cb5c08020",
+        "amount": 764.5886638905986,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "adf473a6-dd46-4caf-b45a-b6c8fe56b1a8",
+        "amount": 28.88154679791203,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "e7f9e433-50cf-4900-8282-ec511cc2cf34",
+        "amount": 181.19818663129155,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "e2e467c4-5128-4a8f-8e37-abfad66b7b85",
+        "amount": 215.50973850909662,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "b4082ac6-cdda-4608-8fa7-bf24e6b6a56c",
+        "amount": 12.141321589964463,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "b7d1e511-9a40-4bd6-a944-dddd087d678c",
+        "amount": 277.30750682441715,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "084d38c4-817d-441a-9e11-057926fa5c3d",
+        "amount": 584.9064959206495,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "236e8409-1c3a-471b-9b0d-107678bfe2bf",
+        "amount": 337.4241468560239,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "93b849a8-ffff-4aac-ac33-de013cc5081f",
+        "amount": 641.359538971651,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "ecf5fc50-d70f-44ec-8863-ed639a98590b",
+        "amount": 88.9763639184198,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "5ed0c15c-b2e2-4f59-9913-b18fe4a9b883",
+        "amount": 396.9545194786863,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "66202a29-c4bb-40b6-9c3c-f280926d7461",
+        "amount": 95.03115730687753,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "5bb8187a-4a42-43eb-b6e0-f922179ac606",
+        "amount": 545.7161474186712,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "354cffeb-5e8c-4cba-9014-0106cd6ebb63",
+        "amount": 49.071401277460566,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "3154d01e-0b52-4c8c-a35d-897e8ad2563c",
+        "amount": 229.94925764434333,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "f08056f0-940a-4b03-981c-7ec55d359cc7",
+        "amount": 248.1733807022947,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "8b10285a-087e-442b-9953-48d884bbd942",
+        "amount": 222.08584475637596,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "579f7fe3-6497-4044-a9b4-11370df86ab9",
+        "amount": 339.7877703997205,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "31e1d080-9e6b-4f55-a9e1-1a3c8a05309c",
+        "amount": 41.75713787210954,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "9b7eebdd-f66d-45ab-96d4-b892332b77bd",
+        "amount": 61.8814161390588,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "017ef455-b3fe-4fbc-882a-343be0e8808a",
+        "amount": 382.22569422954086,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "f0b3b2e4-ea78-4efe-83d7-10760fb721b5",
+        "amount": 66.67638058738508,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "afb8a1d7-22bf-4581-8753-80286ad7874b",
+        "amount": 501.01511561094344,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "c8335c21-e54f-4cd6-a4f5-04d0c414e229",
+        "amount": 43.65786475849491,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "5e821d03-5cff-435b-b0a0-bfa1397cbf84",
+        "amount": 199.69632091018607,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "c63e43cf-a672-4244-a505-42dcbdb8f8b7",
+        "amount": 24.42933296718543,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "16e33e21-57e5-4a03-b591-eafbd54d6744",
+        "amount": 13.345616603062664,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "87725a93-7464-487d-ad85-19a5a20a734e",
+        "amount": 828.7509234667938,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "69dfa125-8b29-4166-9d8f-57b430597399",
+        "amount": 236.07672655349265,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "f127e4c8-fe89-46e4-a712-43efca2a8065",
+        "amount": 451.3250128122256,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "78989d6a-4a48-4f21-9ad7-844127aabe54",
+        "amount": 459.75924400240825,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "cb2d89b2-d145-4a04-b6c4-51059ea11be9",
+        "amount": 721.1450197127137,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "347e850f-1f48-4145-9dda-e8c7cce01226",
+        "amount": 7.904394878462378,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "59908d74-da0d-4152-a4f8-8aa4acbd8754",
+        "amount": 54.83768402303091,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "abd6038c-120e-4470-8de3-15ef077bfb4e",
+        "amount": 95.47909787114466,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "150893ed-89d6-419a-8dba-fdf1d0b3fca5",
+        "amount": 9.064782157057154,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "99dbc85f-56f7-431d-bb9f-eead0d93d6b8",
+        "amount": 541.6078816099845,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "e502699e-4e1e-44b5-ad14-39dd8ce45d98",
+        "amount": 702.6086119498435,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ead925c1-2264-4519-bfc9-af5aa0ecc4fb",
+        "amount": 592.9274756207299,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "dbab6bd9-e653-4128-994f-606f8263f593",
+        "amount": 21.663581959218742,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "91c2f71c-1d4f-44cb-9a33-48ff7ae52c17",
+        "amount": 554.5047705116951,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "fba86226-125e-43ff-9279-bffa67550069",
+        "amount": 64.05204651752929,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "34af808a-c556-4650-a70f-d418ccb79eed",
+        "amount": 153.0391557894258,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "760d1a8c-450b-457c-9046-054d4f9d9a5f",
+        "amount": 214.13951596593856,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "ce8beaa4-f5e9-486c-8c3a-a389228fe95c",
+        "amount": 41.256369627714534,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "3aeb08f6-e1f5-4510-b76d-608490f1e826",
+        "amount": 57.30243274323059,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "259ec166-f4be-4408-95db-ad9c2f30f8dd",
+        "amount": 271.2056165790829,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "af709422-548b-49ca-9f8f-67c985d72f52",
+        "amount": 122.43109105337723,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "1a6eed97-bcdc-4d2e-bd5d-d725d60ebe1d",
+        "amount": 142.62765757772596,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "a106b6f7-e88a-46b1-8b78-f4b84c998c72",
+        "amount": 110.80082109904504,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "b48e03e6-73a1-4c16-9ca2-5799ae313609",
+        "amount": 299.39258231787096,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "f727a44b-be23-444c-a845-5fc80fa08b11",
+        "amount": 254.9609844338362,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "67943e55-9966-4960-b071-754fbc8b7d90",
+        "amount": 176.06946984245386,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "8a387f29-f6bd-49af-8d2b-8fb57171ce51",
+        "amount": 84.82488563114757,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "dd362dbb-064a-4a1c-ba8b-8d8564146806",
+        "amount": 34.8190421398683,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "05babcfd-2174-4055-bc02-abdf2e740ef9",
+        "amount": 210.30322150244373,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "81026d5f-7ee5-4d54-95c0-2e5163977015",
+        "amount": 68.45073152809965,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "7a12fc0a-ea23-4575-bf4d-9f40c73f4fd2",
+        "amount": 436.3444333270195,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "11664a8a-143c-46a6-b5ff-0b16f0885f4c",
+        "amount": 57.22474158933568,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "f10467ac-ac3e-4ea0-b343-0f83f8e41cad",
+        "amount": 568.8218700204438,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "03883ebc-a933-49d3-871b-35498a69d130",
+        "amount": 120.0073638866609,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "c9d0076f-a16e-4e1d-bc17-d69d60b24ffb",
+        "amount": 0,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "30716754-88d5-4439-97fe-64fe714dd1e0",
+        "amount": 259.3883066699603,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "fb61bc5f-caec-4d19-8a8a-90ba2baf1e3e",
+        "amount": 619.4415600775126,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ee7bcfc4-0949-4068-ad31-230c989777cd",
+        "amount": 154.17089865765521,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "cb945750-8524-4e4d-81e7-763b6244c814",
+        "amount": 218.25818002393507,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "86ae6ba8-9983-4c01-9609-808a256956a5",
+        "amount": 31.660709648849853,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "4746788d-c3fb-4a7b-9302-9de115bbe79a",
+        "amount": 612.612626418955,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "a91b16f4-5491-4a3c-a402-3d7b694f4951",
+        "amount": 279.07312876065515,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "f947c56d-2e26-44df-b975-5d893d60b33c",
+        "amount": 80.0501269342756,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "b15f1cc3-af9c-4d62-a246-fc03e3e9e3b4",
+        "amount": 37.636466882133206,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "cdc92c0d-6e21-4635-91fd-476e145fdcc4",
+        "amount": 284.70021173919645,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "8a811a83-4017-401d-be57-3555e97534f1",
+        "amount": 13.32265328566288,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "b04e5493-e77b-4f73-b482-c0d4c864f408",
+        "amount": 44.79223009873944,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "4ffee2fc-b754-4e1b-80b4-adf7d068ab67",
+        "amount": 102.83537849153845,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "6f647272-c342-4d3a-9d30-848b7b0b8e3f",
+        "amount": 114.52335996165074,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "504a02bb-d847-421a-a880-9413e474d0b8",
+        "amount": 38.683814983550235,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "51f1a5ff-f7d9-40fe-8515-0b134f6aa48e",
+        "amount": 76.99556647433839,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "03bc77fb-adcb-423c-a199-0054b36bd599",
+        "amount": 97.73024004618915,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "78849c46-668a-4991-9d20-f0f3255b97d0",
+        "amount": 581.4310024327532,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "320a2b3e-b3c5-44d3-a3d9-aae1835d07fe",
+        "amount": 460.809555509152,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "6b2f4b2c-50b3-4d8f-860b-fe875d29c52c",
+        "amount": 63.60406966156329,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "29d1c1ab-a3bf-4908-948a-894db0fb8108",
+        "amount": 231.38658721085386,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "a6fe8ae6-4c65-4f05-b3e2-1cb3a7febe15",
+        "amount": 1.9594716615802845,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "aeba9023-f95c-433f-998c-264b7869c371",
+        "amount": 78.48133621778332,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "c9a15a42-a562-42d7-896c-f6897ffc9e93",
+        "amount": 231.37053805407447,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ce212a03-3ef2-4f5f-b8db-029a4cf81259",
+        "amount": 549.0116453761141,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "8beee7ff-139d-4507-9a89-c7aacbe26d3d",
+        "amount": 450.5480700150815,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1b3222e0-a63c-4f8a-8ecd-6d79e9b5f1ab",
+        "amount": 488.32375069367333,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "0b5019f8-2ad9-4010-a410-e7e6fbe3bd55",
+        "amount": 31.638482628704978,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "d668bd1f-2966-49f7-b5c1-387c55820457",
+        "amount": 343.3753820214036,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "261bfc70-7163-41f1-a30d-22da0e352f9f",
+        "amount": 4.815379273761109,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "e76c3c3f-4410-4ac8-a070-e91da176dc3c",
+        "amount": 25.5867930231247,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "9b518857-6353-46bf-807f-744f18aaeb95",
+        "amount": 77.27398065455245,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "f8cc11a8-58b3-4b1d-bfca-264a8aa2058b",
+        "amount": 248.84371262935818,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "c760986a-0ea2-496d-958c-ccf427ad79c8",
+        "amount": 501.9095330407698,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "2398f30f-26ed-4bc6-b24b-21cb8beeb113",
+        "amount": 196.283418476367,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "59b23e53-362e-40d4-aacc-4704b5529845",
+        "amount": 598.7383355586591,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "a7e84cfb-7d6f-41b0-9f95-ac32e62d2431",
+        "amount": 317.80325686319304,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "e358cd5c-bf53-4223-84a7-de2e54da26c0",
+        "amount": 785.6999279741848,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "eb084a65-7a9e-4157-8a2f-aecd2516fec0",
+        "amount": 67.26061886099703,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "1f94321b-1cbb-4bba-a837-2983b4ca3961",
+        "amount": 781.3513674319373,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "71358117-54ab-401c-b2e8-1d80e7d5ad3c",
+        "amount": 180.4843974227617,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "bb313a07-f17b-4079-967f-fc2155c82700",
+        "amount": 169.24598462898848,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "78806d61-958f-498a-8191-7f2b108ca2e3",
+        "amount": 569.5326996037589,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "cddcf696-ffce-43c0-9972-adccf0401e55",
+        "amount": 453.103412531835,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "88422fc5-5d32-4eb3-a6ce-22717a21429e",
+        "amount": 125.37183096375902,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "cb041ec1-fdfa-417b-b45e-9367b5c90e56",
+        "amount": 202.38907448861008,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "5cb6266f-0088-4e88-92ad-ab5431666f61",
+        "amount": 415.0483209454821,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "69bd2248-aa3c-4620-98ed-cc5d0576fe05",
+        "amount": 283.51338963448876,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "2d59d883-9803-4780-9224-c6bf996b95a3",
+        "amount": 269.1164071393143,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "daaa1d06-3358-41cc-bf39-74c09e4fd0a2",
+        "amount": 6.324637250396526,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "a4aa51b0-6b53-4d29-a001-51748bea30b4",
+        "amount": 296.28262733593016,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "9dbb4809-24fd-4e78-91a6-b629f301c0e7",
+        "amount": 80.05369222275304,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "507d478f-9030-4c32-91f2-f0a2e8ed3c9a",
+        "amount": 9.916925041151899,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "31af62d8-1a2b-4383-8882-c16971953483",
+        "amount": 26.867489913751445,
+        "comment": "",
+        "date": 1632755177925,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "912a4b03-4d70-428b-93e8-eabdc9c860c1",
+        "amount": 18.94301505487221,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ec0391d5-de8d-4e1c-b0ee-b3df467efdae",
+        "amount": 318.02558693107665,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "05c1a38d-4bbd-48c2-b861-972d2b9089a6",
+        "amount": 109.03355951258044,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "242fc515-cbf1-478c-be32-308e8656f238",
+        "amount": 213.54856359886145,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "b2537994-9742-4860-842b-e6f89e04ba6f",
+        "amount": 3.977848092114451,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "ba40080c-1b07-4699-ac11-046b8d0dd757",
+        "amount": 2.066857389459963,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "987001e4-e103-4669-b0ee-21bc4fd135dd",
+        "amount": 24.901162632732824,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "00b19463-84ca-4f9f-9e34-109ca981b6f8",
+        "amount": 152.85508630832237,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "8730b5a3-13ff-4a2f-8f43-371b264aabb0",
+        "amount": 106.87548019726691,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "2528e8d3-c6de-4b6c-a0e0-9fd4366538aa",
+        "amount": 0.5123246523402307,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "93257646-6e74-40d4-9df1-93e6ce638408",
+        "amount": 391.84190764613385,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ddf256cb-b121-4ee3-9c59-c4d1590198c6",
+        "amount": 116.19265172902801,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "fe579379-bb5c-4f89-8bc0-4971aef1dca9",
+        "amount": 18.37053372792907,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "f0b48b68-ad63-4037-b8e5-952f94370fdc",
+        "amount": 656.4029734555832,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "6a546e4d-fdce-4744-b6d9-c99b7ad7e402",
+        "amount": 80.84463496289685,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "f346ecc2-93a3-4c29-be87-bd9569b898b3",
+        "amount": 181.04084525577213,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "d98b8a54-5a1a-42f9-b200-a7b498984590",
+        "amount": 45.6955731283459,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "4533f163-955c-4221-a68c-f96ccfd2c9bf",
+        "amount": 4.202740321471634,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "aba2abfd-72f6-4804-a20e-09d9b29c2481",
+        "amount": 169.84652418019957,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "dba5ffe9-9424-4b9e-a30e-efe91a37ea8f",
+        "amount": 17.57031914312456,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "3109d7ab-6365-4115-9c98-7b88c2ea787c",
+        "amount": 26.284458640144194,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "536d5803-b30e-47c4-a2c5-8d8ef671ba4d",
+        "amount": 122.86086286485772,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "f80dcad4-4fa4-4532-ac11-db457fdbad67",
+        "amount": 116.41909674460084,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "aec5f019-6a42-44ab-bdf5-6f1d428f75b1",
+        "amount": 368.91431859572816,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "0334b406-6b4a-42d4-a542-0d548782b122",
+        "amount": 31.903229061849007,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "3a14e07e-2e6f-45f4-889b-8935fa040e38",
+        "amount": 20.885441708989788,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "53c16aea-e667-4ae8-a432-91c93a470ce2",
+        "amount": 211.05913795770186,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "34fdde1e-1a50-45b8-8a1c-819775015d77",
+        "amount": 60.949754773259016,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "8f2919e3-7ffa-41b2-b5a0-46dffeb77eff",
+        "amount": 219.63020669626897,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "60d58ff6-628f-4937-82fd-448ae1d588c3",
+        "amount": 18.88842473342772,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "9c9c350e-db04-4e28-9756-f1b561eecd32",
+        "amount": 56.92929742904222,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "76c1d517-b5de-414e-8d56-73a12361951f",
+        "amount": 143.30645282542133,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "4afd07e6-75bb-4897-8892-ab28491bff9e",
+        "amount": 200.13677663578287,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "099d6edb-89db-4ef6-8491-d05f152cb37d",
+        "amount": 30.786334896710173,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "16bd3bb5-6a90-4cc7-b746-ac0a5b30391c",
+        "amount": 87.05282218265283,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "8c73e687-0655-401f-8087-33b5a4b58fdb",
+        "amount": 650.8352888683047,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "9659fc17-4256-4c6b-ad66-70684261dbcd",
+        "amount": 126.46227985539191,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "7607884b-4d03-4a3e-8012-6555052bab9f",
+        "amount": 283.17777885381656,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "ceb0941f-0e7b-4848-8ea5-d98784325317",
+        "amount": 15.871752554696537,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "604bc51f-dc7b-4ec4-8a85-72875b21b55c",
+        "amount": 45.281975072034,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "1807db71-03b6-4946-858b-b1a4a59f1e34",
+        "amount": 221.4561155492853,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "d93569de-b346-4312-8aec-0303c1276358",
+        "amount": 3.1691571157680833,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "02f20d96-c3b9-468a-8f41-56478975bddf",
+        "amount": 594.318655844145,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "c340803c-a68e-476d-a5dd-37308441215c",
+        "amount": 843.9882807751051,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "a43a26f2-c735-4a54-a584-f546830162b0",
+        "amount": 749.5769786689287,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "0840dbee-1170-4e58-8673-3e443167c8e3",
+        "amount": 492.29794587728315,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "3f39ede8-e480-45c1-a619-15eeb177214b",
+        "amount": 207.98554639181307,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "96c1dda7-2662-4ade-bf61-ddce323f3f1e",
+        "amount": 46.156993476806264,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "41ef416d-4dbe-47f1-b765-4d68c83cbe8d",
+        "amount": 0.08572287074277796,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "de0bc7a8-a0cc-4708-bcc9-4d4325c53b28",
+        "amount": 89.05618398983368,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "a218f3e5-1950-4160-b422-6638582dcfbc",
+        "amount": 69.24629348184497,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "5c76d25e-a180-465b-bf35-4814fbdaf7e2",
+        "amount": 332.68215132017866,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "a67bd262-6edb-498f-a32d-1308ba533e49",
+        "amount": 45.295295437026226,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0e06829a-d53e-4813-8a6b-b0ab81a4547f",
+        "amount": 593.5955030244381,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "b8d87c01-568d-4d04-b2dd-f7d9a779ddb4",
+        "amount": 140.34487145504548,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "856937bd-0dc8-42e9-b3a5-cde5bad83d94",
+        "amount": 300.8693890463903,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "c8b4f558-b86a-40ee-abf5-aaa38f84f340",
+        "amount": 650.7614603610625,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "a4de0d4e-bb38-42ad-b35e-bda1acea69b6",
+        "amount": 272.5399775116708,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "8d5d2dcc-c00d-49fa-9ae8-8425e213b58b",
+        "amount": 342.18291539541565,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "5c22c6b4-74dd-4612-b082-f7ce64ac61f8",
+        "amount": 594.1401068604363,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "1ab80b89-c219-431b-a722-c6b45cdbdc0c",
+        "amount": 482.16340065411237,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "b57faecf-24b3-45cd-81ca-97a18a0bcc64",
+        "amount": 59.450202672330434,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "e6be065f-b7fa-4472-b387-66a8fec55a1f",
+        "amount": 146.95957686207558,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "b8a33213-1329-41aa-b127-743c62907d0d",
+        "amount": 377.77648430043456,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "5fd00575-1ace-4722-9840-b9c0416888ca",
+        "amount": 56.07557027798709,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "47fabeb3-680a-4a19-ae44-f91469fdac29",
+        "amount": 27.487584084649313,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "4125c7db-0e83-4fc4-b412-49d95a576270",
+        "amount": 429.9852614794278,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "8e4ce07d-4326-4e36-9f59-5977eee5f072",
+        "amount": 344.64659643991547,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "9fff12e2-09ae-4e03-8c5a-60dd96c787da",
+        "amount": 293.77516489112674,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "a4f63d24-a556-4370-be94-e6492f68ab77",
+        "amount": 220.347630962463,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "67c5e949-5f56-4325-98c4-c2717f9c453b",
+        "amount": 131.1737407866624,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "892dd34b-7224-41b2-b44f-e9dbc8413147",
+        "amount": 237.8484105820713,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "03d727a1-41bd-49a9-a6ef-489b2297d73a",
+        "amount": 75.19429574735844,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "bdf6a128-91aa-432f-8fcb-2a90bfa5388e",
+        "amount": 451.10671540640107,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 323,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "87b6f7f0-1394-48b9-bfd2-69f7926d0217",
+        "amount": 278.8248067482828,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "57411476-3910-4c90-80d8-041a2ba5381c",
+        "amount": 81.23426085131344,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "524a1e3a-af30-4084-8b9f-b154f188d7d2",
+        "amount": 120.44312937831825,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "7f94d756-812d-416e-b4ea-8681c821204d",
+        "amount": 186.77387084555627,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 3566000020000410,
+            "csc_code": 589,
+            "cardholder_name": "Kattie Caraher",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "JCB"
+        },
+        "uid": "93a2eb96-f960-4c57-b6a0-cb8f91eae6b8",
+        "amount": 192.65123964234616,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "6b5d63a2-f6ed-4fff-83d4-f31a6f4dc287",
+        "amount": 114.39315428971435,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "69912a0a-346d-498c-8fc9-afd2689cc257",
+        "amount": 85.85271058073181,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "bf040080-31e4-4efc-8832-5d37a1457850",
+        "amount": 449.26407932029525,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0725f243-9b3b-498f-8470-0415dc121dca",
+        "amount": 13.888833056869256,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "9c60eb4d-ee3c-4e51-84ab-d9e79698d443",
+        "amount": 136.01701782037756,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0155f2d3-d47c-4524-bd2c-4a612e54c9ae",
+        "amount": 10.357269865165808,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "6f2075d0-bf21-4503-8187-902b7e752b6d",
+        "amount": 622.886171387189,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "ebb0f2dc-3294-4a71-89dc-648d71628843",
+        "amount": 489.9950401855209,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "66db1259-2333-43e8-a711-fd2f55f38b38",
+        "amount": 349.9371671548864,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "218b7675-7def-4f33-8f0a-c4b9844d01bc",
+        "amount": 4.255082385623804,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "6e768888-e69d-471e-980c-68acc34e667d",
+        "amount": 35.4574953184592,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "31d2e421-194f-4a4d-a23b-ea7b5969810a",
+        "amount": 103.62644442017867,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "612944d0-660e-4cad-ad36-a0faa99baf5a",
+        "amount": 199.6079523408811,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "4d1be5e7-63b9-4537-b557-9694c5b8b576",
+        "amount": 60.86399569913111,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "74763a17-777f-478b-b448-01e2d413c0bb",
+        "amount": 3.095325463465885,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "71e1e8ef-71d8-4faf-acaa-903cdaa81785",
+        "amount": 81.15160333978376,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "9ded66a1-6999-46d9-8b14-3f28255b7cc9",
+        "amount": 659.2839848125043,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "bd03ae7d-a773-4394-b6c1-94ea59243878",
+        "amount": 37.356994784569395,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "f667f55c-fe79-41c6-9212-5469fa01b7b1",
+        "amount": 112.30935486052041,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "ae2483a8-9b04-4af8-a230-491d6a6a1886",
+        "amount": 73.62089057149626,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "23ddd26c-afde-4f5f-91c8-96df11426fb4",
+        "amount": 16.61513390602738,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "abbe025c-7239-4efe-8002-abad28f25915",
+        "amount": 120.70372435776527,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "60133625-b647-4537-a580-b264622774ea",
+        "amount": 22.981633915776854,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "aa275ccc-3d25-4cf9-8158-c3878c4333d1",
+        "amount": 38.35017366671394,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2223000048410010,
+            "csc_code": 102,
+            "cardholder_name": "Olenolin Glason",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "85fe0706-6ef3-4f56-8348-932820a3acfc",
+        "amount": 98.9422377022616,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "8384e132-225f-4099-91ee-770343d79a3c",
+        "amount": 73.82257548555542,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "5a6cb85b-8d82-49bf-a641-4006e9444d74",
+        "amount": 192.688493175701,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "cb04d867-7c7a-4023-9eb0-8324c0f5c514",
+        "amount": 476.9156724325017,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "ffca12c9-e5c3-4c8e-ad69-dfd5ec60dada",
+        "amount": 190.94125910117316,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "37dbd672-361b-4d3b-b686-08ba97477754",
+        "amount": 331.2736368380495,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "6f74e87e-ea88-4f32-98dc-5f5204a11bee",
+        "amount": 368.48737773909045,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "2cad2aa7-5af0-4f91-bfc3-fc13c9da4b37",
+        "amount": 454.1879413212891,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6011000991300009,
+            "csc_code": 964,
+            "cardholder_name": "Ardra Frankis",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "d9464460-6a53-42d0-bbc1-77203f7c0a5e",
+        "amount": 64.16261817663226,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "101ea13d-8fa4-4d89-89c1-d964a4038485",
+        "amount": 111.24030951219544,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "1e9474c1-7b52-45dc-8c58-5e3e96be741d",
+        "amount": 112.67482732017294,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4001919257537193,
+            "csc_code": 393,
+            "cardholder_name": "Nealon Manifield",
+            "expiration_date_month": 1,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0b3290c6-c700-45cf-bc9b-dc3708d8fb3f",
+        "amount": 502.8050327932177,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "10a7946b-28f7-420c-ba98-8320be43ec33",
+        "amount": 34.458914481545804,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "2fe1120f-cdbe-493f-b18d-48a3d481424d",
+        "amount": 13.941368355853879,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4917484589897107,
+            "csc_code": 420,
+            "cardholder_name": "Jennica O'Crevy",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0d1f11d3-e9a0-4a66-9fc6-e6811e73a616",
+        "amount": 336.6101887063679,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "191faef3-998b-410e-a128-4047c5213adc",
+        "amount": 310.0289385553238,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "18e67a87-dd33-42dd-9738-631c3c09046d",
+        "amount": 32.59899964003557,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6034932528973614,
+            "csc_code": 412,
+            "cardholder_name": "Dilan Renn",
+            "expiration_date_month": 3,
+            "expiration_date_year": 2023,
+            "issuer": "Cencosud"
+        },
+        "uid": "dc46985b-0cca-459e-b8cd-5cdc5e546855",
+        "amount": 77.2952256747975,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "2194a994-da2c-45a8-8a81-2473f5666be6",
+        "amount": 72.49830609576466,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "8e3e8034-243b-4908-98c4-79f3a1e9f313",
+        "amount": 278.6513055222319,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 76,
+            "cardholder_name": "Simone McPartling",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "0c661437-12aa-4894-951f-7b44437724cf",
+        "amount": 82.58335960212635,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "a3674d9b-a3ef-46ff-89bb-d4d70fe33792",
+        "amount": 412.48735865937596,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "22ee47b2-c517-4d2d-9f98-1a156187411f",
+        "amount": 287.82416437571095,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 2222420000001113,
+            "csc_code": 812,
+            "cardholder_name": "Cilka Sindell",
+            "expiration_date_month": 8,
+            "expiration_date_year": 2020,
+            "issuer": "Mastercard"
+        },
+        "uid": "4db91d75-9425-4f59-927c-051e98114618",
+        "amount": 149.38667344661968,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "7fe7da28-55fe-4443-813a-ec85574d5715",
+        "amount": 70.60999896973789,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "NAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "b66ed7fa-09ad-467b-bfab-bff24bd9bedc",
+        "amount": 3.601713282473397,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 60115564485789460,
+            "csc_code": 231,
+            "cardholder_name": "Raynell Hennington",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Discover"
+        },
+        "uid": "9bc60710-711d-4418-a8e7-827ee8a18880",
+        "amount": 149.23651224360862,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "b490905d-3fae-4579-ace1-a1ad493f3894",
+        "amount": 101.67019130422631,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 6271701225979642,
+            "csc_code": 557,
+            "cardholder_name": "Orelle Renvoise",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2023,
+            "issuer": "Cabal"
+        },
+        "uid": "edd09781-dc2e-4f0b-b259-1f6f7f5310b1",
+        "amount": 180.4318081553352,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "USD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "7f5985d3-8cb0-4f53-bcdf-af2306e1cfe3",
+        "amount": 230.1191727692028,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 355,
+            "cardholder_name": "Cobb Bruna",
+            "expiration_date_month": 4,
+            "expiration_date_year": 2023,
+            "issuer": "Mastercard"
+        },
+        "uid": "fa4658ba-1e16-49b2-b8e1-c5bc8df9004f",
+        "amount": 288.14837935905473,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    },
+    {
+        "credit_card": {
+            "card_number": 374245455400126,
+            "csc_code": 654,
+            "cardholder_name": "Gale Persian",
+            "expiration_date_month": 5,
+            "expiration_date_year": 2023,
+            "issuer": "Amex"
+        },
+        "uid": "f472c39e-6f24-4ce1-8fae-fa204b120952",
+        "amount": 66.96920997303428,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4007702835532454,
+            "csc_code": 132,
+            "cardholder_name": "Marvin Tufts",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "93cfc6fa-6bd1-4220-8162-4b8d143796b1",
+        "amount": 483.4917742164399,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "CAD"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "15329c4f-7339-4b69-a90f-9102a43b3e2e",
+        "amount": 494.6333058862468,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 5425233430109903,
+            "csc_code": 756,
+            "cardholder_name": "Osgood Twatt",
+            "expiration_date_month": 12,
+            "expiration_date_year": 2004,
+            "issuer": "Mastercard"
+        },
+        "uid": "d60298d7-a4a0-4837-8b1d-8cb63b768fa5",
+        "amount": 4.231498944067776,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 6250941006528599,
+            "csc_code": 874,
+            "cardholder_name": "Levy Romeuf",
+            "expiration_date_month": 6,
+            "expiration_date_year": 2023,
+            "issuer": "China Union Pay"
+        },
+        "uid": "ad86c27c-4ab3-4be6-aaa3-0951111ee911",
+        "amount": 231.01218692238436,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "MWK"
+    },
+    {
+        "credit_card": {
+            "card_number": 5011054488597827,
+            "csc_code": 374,
+            "cardholder_name": "Jacquelynn Moyles",
+            "expiration_date_month": 9,
+            "expiration_date_year": 2023,
+            "issuer": "Argencard"
+        },
+        "uid": "e124af04-52cd-4e96-be26-7abf41110aaa",
+        "amount": 116.73628753760858,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "EUR"
+    },
+    {
+        "credit_card": {
+            "card_number": 4263982640269299,
+            "csc_code": 173,
+            "cardholder_name": "Laird Mulvin",
+            "expiration_date_month": 2,
+            "expiration_date_year": 2023,
+            "issuer": "Visa"
+        },
+        "uid": "9598a29b-1baa-43bd-997d-22d3f502bb1e",
+        "amount": 276.33505961307253,
+        "comment": "",
+        "date": 1632755177926,
+        "currency": "KYD"
+    }
 ]

--- a/hand-in/credit-card-server/src/transaction.router.ts
+++ b/hand-in/credit-card-server/src/transaction.router.ts
@@ -7,7 +7,7 @@ router.use(cors())
 
 router.get('/', controller.list)
 router.post('/', controller.create)
-router.delete('', controller.remove)
+router.delete('/:transaction_uid', controller.remove)
 router.get('/generate', controller.generate)
 
 export { router }

--- a/hand-in/credit-card-server/src/transaction.router.ts
+++ b/hand-in/credit-card-server/src/transaction.router.ts
@@ -1,9 +1,10 @@
-import { Router } from 'express'
+import { Router, json } from 'express'
 import * as cors from 'cors'
 import * as controller from './transaction.controller'
 
 const router = Router()
 router.use(cors())
+router.use(json())
 
 router.get('/', controller.list)
 router.post('/', controller.create)

--- a/hand-in/credit-card-server/src/transaction.type.ts
+++ b/hand-in/credit-card-server/src/transaction.type.ts
@@ -6,6 +6,7 @@ export interface Transaction {
   comment: string;
   date: number;
   currency: string;
+  uid: string;
 }
 
 export const CURRENCIES = [

--- a/hand-in/credit-card-server/src/transaction.type.ts
+++ b/hand-in/credit-card-server/src/transaction.type.ts
@@ -6,7 +6,7 @@ export interface Transaction {
   comment: string;
   date: number;
   currency: string;
-  uid: string;
+  uid?: string;
 }
 
 export const CURRENCIES = [

--- a/hand-in/hand-in-1.md
+++ b/hand-in/hand-in-1.md
@@ -38,7 +38,8 @@ The solution will provide the accounting department with an overview of use for 
 - `F4.3.1` Field `cardholder_name` is required
 - `F4.4.1` Field `expiration_date_month` must be in range `1-12`
 - `F4.4.2` Field `expiration_date_month` is required
-- `F4.5.1` Field `expiration_date_year` must be in range `1-31` 
+- `F4.5.1` Field `expiration_date_year` must be in range `1-31`
+<!-- What is the maximum  validity period for at credit card--> 
 - `F4.5.2` Field `expiration_date_year` is required
 
 `F5` Transactions screen

--- a/slides/decks/05/index.html
+++ b/slides/decks/05/index.html
@@ -571,6 +571,20 @@
 							</li>
 						</ul>
 					</li>
+					<li>Other layout methods
+						<ul>
+							<li>Simple positioning
+								<ul>
+									<li>Relative, absolute, fixed, sticky</li>
+								</ul>
+							</li>
+							<li>Floats
+								<ul>
+									<li>Remove elements from the normal flow and float around them</li>
+								</ul>
+							</li>
+						</ul>
+					</li>
 				</ul>
 				<aside class="notes" aria-label="notes">
 					<h4>References</h4>


### PR DESCRIPTION
Added two new endpoint for credit card and transaction deletion:
- `DELETE /credit_cards/:card_number`
- `DELETE /transactions/:transaction_uid`

I have added a new field to `Transaction` and `CreditCard`, they now have a new `uid` field that is generated upon creation. Please consider using that when deleting transactions to avoid unwanted behavior. I have added a new dependency to `uuid`, so you will have to run `npm i` again.

The transaction router were missing the `json` middleware, so that is added as well.